### PR TITLE
Add Russian (ru_RU) translation

### DIFF
--- a/translations/rpcs3_ru_RU.ts
+++ b/translations/rpcs3_ru_RU.ts
@@ -1,0 +1,18640 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1" language="ru_RU">
+<context>
+    <name>AutoPauseConfigDialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="219"/>
+        <source>&amp;Ok</source>
+        <translation>&amp;ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="220"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="224"/>
+        <source>Specify ID of System Call or Function Call below. You need to use a Hexadecimal ID.</source>
+        <translation>Укажите ID системного вызова или функции ниже. Необходимо использовать шестнадцатеричный ID.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="227"/>
+        <source>Currently it gets an id of &quot;Unset&quot;.</source>
+        <translation>В данный момент используется ID «Не задан».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="285"/>
+        <source>Current value: %1 (%2)</source>
+        <translation>Текущее значение: %1 (%2)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="285"/>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="285"/>
+        <source>Conversion failed</source>
+        <translation>Ошибка преобразования</translation>
+    </message>
+</context>
+<context>
+    <name>Buffer</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="391"/>
+        <source>Save Image At</source>
+        <translation>Сохранить изображение в</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="397"/>
+        <source>Save Image</source>
+        <translation>Сохранить изображение</translation>
+    </message>
+</context>
+<context>
+    <name>DeviceChoice</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="182"/>
+        <source>DISABLE</source>
+        <translation>ОТКЛЮЧИТЬ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="202"/>
+        <source>-- Disabled --</source>
+        <translation>-- Отключено --</translation>
+    </message>
+</context>
+<context>
+    <name>Localized</name>
+    <message numerus="yes">
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="18"/>
+        <source>%Ln day(s)</source>
+        <translation>
+            <numerusform>%Ln день</numerusform>
+            <numerusform>%Ln дня</numerusform>
+            <numerusform>%Ln дней</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="19"/>
+        <source>%Ln hour(s)</source>
+        <translation>
+            <numerusform>%Ln час</numerusform>
+            <numerusform>%Ln часа</numerusform>
+            <numerusform>%Ln часов</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="20"/>
+        <source>%Ln minute(s)</source>
+        <translation>
+            <numerusform>%Ln минута</numerusform>
+            <numerusform>%Ln минуты</numerusform>
+            <numerusform>%Ln минут</numerusform>
+        </translation>
+    </message>
+    <message numerus="yes">
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="21"/>
+        <source>%Ln second(s)</source>
+        <translation>
+            <numerusform>%Ln секунда</numerusform>
+            <numerusform>%Ln секунды</numerusform>
+            <numerusform>%Ln секунд</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="28"/>
+        <source>%0 and %1</source>
+        <comment>Days and hours</comment>
+        <translation>%0 и %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="36"/>
+        <source>%0 and %1</source>
+        <comment>Hours and minutes</comment>
+        <translation>%0 и %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="42"/>
+        <source>%0 and %1</source>
+        <comment>Minutes and seconds</comment>
+        <translation>%0 и %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="74"/>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="61"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="82"/>
+        <source>480</source>
+        <translation>480</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="83"/>
+        <source>576</source>
+        <translation>576</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="84"/>
+        <source>720</source>
+        <translation>720</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="85"/>
+        <source>1080</source>
+        <translation>1080</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="86"/>
+        <source>480 16:9</source>
+        <translation>480 16:9</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="87"/>
+        <source>576 16:9</source>
+        <translation>576 16:9</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="94"/>
+        <source>LPCM 2.0</source>
+        <translation>LPCM 2.0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="95"/>
+        <source>LPCM 5.1</source>
+        <translation>LPCM 5.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="96"/>
+        <source>LPCM 7.1</source>
+        <translation>LPCM 7.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="97"/>
+        <source>Dolby Digital 5.1</source>
+        <translation>Dolby Digital 5.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="98"/>
+        <source>DTS 5.1</source>
+        <translation>DTS 5.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.cpp" line="105"/>
+        <source>The PS3 Interface (XMB, or VSH)</source>
+        <translation>Интерфейс PS3 (XMB или VSH)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="25"/>
+        <source>Music App</source>
+        <translation>Музыка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="26"/>
+        <source>Photo App</source>
+        <translation>Фото</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="27"/>
+        <source>Store App</source>
+        <translation>Магазин</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="28"/>
+        <source>TV App</source>
+        <translation>Телевидение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="29"/>
+        <source>Video App</source>
+        <translation>Видео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="30"/>
+        <source>Broadcast Video</source>
+        <translation>Трансляция видео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="31"/>
+        <source>Disc Game</source>
+        <translation>Игра на диске</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="32"/>
+        <source>HDD Game</source>
+        <translation>Игра на HDD</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="33"/>
+        <source>Home</source>
+        <translation>Главная</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="34"/>
+        <source>Network</source>
+        <translation>Сеть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="35"/>
+        <source>Store</source>
+        <translation>Магазин</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="36"/>
+        <source>Web TV</source>
+        <translation>Веб-ТВ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="37"/>
+        <source>Operating System</source>
+        <translation>Операционная система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="40"/>
+        <source>PS2 Classics</source>
+        <translation>Классика PS2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="41"/>
+        <source>PS2 Game</source>
+        <translation>Игра PS2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="44"/>
+        <source>PS1 Classics</source>
+        <translation>Классика PS1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="47"/>
+        <source>PSP Game</source>
+        <translation>Игра PSP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="48"/>
+        <source>PSP Minis</source>
+        <translation>PSP Minis</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="49"/>
+        <source>PSP Remasters</source>
+        <translation>PSP Remasters</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="52"/>
+        <source>PS3 Game Data</source>
+        <translation>Данные игры PS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="53"/>
+        <source>PS2 Emulator Data</source>
+        <translation>Данные эмулятора PS2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="56"/>
+        <source>PS3 Save Data</source>
+        <translation>Сохранения PS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="57"/>
+        <source>PSP Minis Save Data</source>
+        <translation>Сохранения PSP Minis</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="60"/>
+        <source>Trophy</source>
+        <translation>Трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="62"/>
+        <source>Other</source>
+        <translation>Другое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="102"/>
+        <source>0+</source>
+        <translation>0+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="103"/>
+        <source>3+</source>
+        <translation>3+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="104"/>
+        <source>7+</source>
+        <translation>7+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="105"/>
+        <source>10+</source>
+        <translation>10+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="106"/>
+        <source>12+</source>
+        <translation>12+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="107"/>
+        <source>15+</source>
+        <translation>15+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="108"/>
+        <source>16+</source>
+        <translation>16+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="109"/>
+        <source>17+</source>
+        <translation>17+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="110"/>
+        <source>18+</source>
+        <translation>18+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="111"/>
+        <source>Level 10</source>
+        <translation>Уровень 10</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized.h" line="112"/>
+        <source>Level 11</source>
+        <translation>Уровень 11</translation>
+    </message>
+</context>
+<context>
+    <name>Mapping</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="266"/>
+        <source>MAP</source>
+        <translation>НАЗНАЧИТЬ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="267"/>
+        <source>UNMAP</source>
+        <translation>УБРАТЬ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="268"/>
+        <source>Reverse</source>
+        <translation>Инвертировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="272"/>
+        <source>Pressed</source>
+        <translation>Нажато</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="326"/>
+        <source>Input %0 for %1, timeout in %2 %3</source>
+        <translation>Ввод %0 для %1, таймаут через %2 %3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="326"/>
+        <source>axis</source>
+        <translation>ось</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="326"/>
+        <source>button/hat</source>
+        <translation>кнопка/крестовина</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="326"/>
+        <source>seconds</source>
+        <translation>секунд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="326"/>
+        <source>second</source>
+        <translation>секунда</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="977"/>
+        <source>RPCS3 should never be run from a temporary location!
+Please install RPCS3 in a persistent location.
+Current location:
+%0</source>
+        <translation>RPCS3 нельзя запускать из временной папки!
+Пожалуйста, установите RPCS3 в постоянное место.
+Текущее расположение:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="990"/>
+        <source>RPCS3 should never be run from an archive!
+Please install RPCS3 in a persistent location.
+Current location:
+%0</source>
+        <translation>RPCS3 нельзя запускать из архива!
+Пожалуйста, установите RPCS3 в постоянное место.
+Текущее расположение:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="1004"/>
+        <source>RPCS3 should never be run from a OneDrive path!
+Please move RPCS3 to a location not synced by OneDrive.
+Current location:
+%0</source>
+        <translation>RPCS3 нельзя запускать из папки OneDrive!
+Пожалуйста, переместите RPCS3 в место, не синхронизируемое OneDrive.
+Текущее расположение:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="1129"/>
+        <source>Invalid command-line arguments!</source>
+        <translation>Неверные аргументы командной строки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="1129"/>
+        <source>Cannot perform multiple installations at the same time!</source>
+        <translation>Невозможно выполнять несколько установок одновременно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="1323"/>
+        <source>Missing command-line arguments!</source>
+        <translation>Отсутствуют аргументы командной строки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3.cpp" line="1323"/>
+        <source>Cannot run no-gui mode without boot target.
+Terminating...</source>
+        <translation>Невозможно запустить режим без GUI без цели загрузки.
+Завершение...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="134"/>
+        <source>Unknown: %0</source>
+        <translation>Неизвестно: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="711"/>
+        <source>Pause the SPU Thread!</source>
+        <translation>Приостановите поток SPU!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="711"/>
+        <source>Cannot perform SPU capture due to the thread needing manual pausing!</source>
+        <translation>Невозможно выполнить захват SPU — поток требует ручной приостановки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="83"/>
+        <source>Steering</source>
+        <translation>Руль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="84"/>
+        <source>Throttle</source>
+        <translation>Газ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="85"/>
+        <source>Brake</source>
+        <translation>Тормоз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="86"/>
+        <source>Clutch</source>
+        <translation>Сцепление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="87"/>
+        <source>Shift up</source>
+        <translation>Повысить передачу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="88"/>
+        <source>Shift down</source>
+        <translation>Понизить передачу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="89"/>
+        <source>Up</source>
+        <translation>Вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="90"/>
+        <source>Down</source>
+        <translation>Вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="91"/>
+        <source>Left</source>
+        <translation>Влево</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="92"/>
+        <source>Right</source>
+        <translation>Вправо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="93"/>
+        <source>Triangle</source>
+        <translation>Triangle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="94"/>
+        <source>Cross</source>
+        <translation>Cross</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="95"/>
+        <source>Square</source>
+        <translation>Square</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="96"/>
+        <source>Circle</source>
+        <translation>Circle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="97"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="98"/>
+        <source>L3</source>
+        <translation>L3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="99"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="100"/>
+        <source>R3</source>
+        <translation>R3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="101"/>
+        <source>L4
+Plus</source>
+        <translation>L4
+Plus</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="102"/>
+        <source>L5
+Minus</source>
+        <translation>L5
+Minus</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="103"/>
+        <source>R4
+Dial CW</source>
+        <translation>R4
+По часовой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="104"/>
+        <source>R5
+Dial CCW</source>
+        <translation>R5
+Против часовой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="105"/>
+        <source>Dial Center</source>
+        <translation>Центр диска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="106"/>
+        <source>Select</source>
+        <translation>Выбрать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="107"/>
+        <source>Start</source>
+        <translation>Старт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="108"/>
+        <source>PS</source>
+        <translation>PS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="109"/>
+        <source>Gear 1</source>
+        <translation>Передача 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="110"/>
+        <source>Gear 2</source>
+        <translation>Передача 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="111"/>
+        <source>Gear 3</source>
+        <translation>Передача 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="112"/>
+        <source>Gear 4</source>
+        <translation>Передача 4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="113"/>
+        <source>Gear 5</source>
+        <translation>Передача 5</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="114"/>
+        <source>Gear 6</source>
+        <translation>Передача 6</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="115"/>
+        <source>Gear R</source>
+        <translation>Передача R</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="252"/>
+        <source>Tracking not supported!</source>
+        <translation>Отслеживание не поддерживается!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="252"/>
+        <source>The PS Move tracking is not yet supported on this operating system.</source>
+        <translation>Отслеживание PS Move пока не поддерживается в данной операционной системе.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="85"/>
+        <source>Failed to connect to RPCN server:
+%0</source>
+        <translation>Не удалось подключиться к серверу RPCN:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="86"/>
+        <source>Error Connecting to RPCN!</source>
+        <translation>Ошибка подключения к RPCN!</translation>
+    </message>
+</context>
+<context>
+    <name>Tooltips</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="23"/>
+        <source>These libraries are LLE&apos;d by default (lower list), selection will switch to HLE.
+LLE - &quot;Low Level Emulated&quot;, function code inside the selected SPRX file will be used for exported firmware functions.
+HLE - &quot;High Level Emulated&quot;, alternative emulator code will be used instead for exported firmware functions.
+If chosen wrongly, games will not work! If unsure, leave both lists empty. HLEing all SPRX allows to boot without firmware installed. (experimental)</source>
+        <translation>Эти библиотеки по умолчанию эмулируются через LLE (нижний список), выбор переключит на HLE.
+LLE — «Low Level Emulated», код функций из выбранного SPRX-файла используется для экспортируемых функций прошивки.
+HLE — «High Level Emulated», вместо них используется альтернативный код эмулятора.
+При неверном выборе игры не будут работать! Если не уверены — оставьте оба списка пустыми. Включение HLE для всех SPRX позволяет запускать игры без установленной прошивки. (экспериментально)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="24"/>
+        <source>These libraries are HLE&apos;d by default (upper list), selection will switch to LLE.
+LLE - &quot;Low Level Emulated&quot;, function code inside the selected SPRX file will be used for exported firmware functions.
+HLE - &quot;High Level Emulated&quot;, alternative emulator code will be used instead for exported firmware functions.
+If chosen wrongly, games will not work! If unsure, leave both lists empty. HLEing all SPRX allows to boot without firmware installed. (experimental)</source>
+        <translation>Эти библиотеки по умолчанию эмулируются через HLE (верхний список), выбор переключит на LLE.
+LLE — «Low Level Emulated», код функций из выбранного SPRX-файла используется для экспортируемых функций прошивки.
+HLE — «High Level Emulated», вместо них используется альтернативный код эмулятора.
+При неверном выборе игры не будут работать! Если не уверены — оставьте оба списка пустыми. Включение HLE для всех SPRX позволяет запускать игры без установленной прошивки. (экспериментально)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="25"/>
+        <source>Select to LLE. (HLE by default)</source>
+        <translation>Выбрать LLE. (по умолчанию HLE)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="26"/>
+        <source>Select to HLE. (LLE by default)</source>
+        <translation>Выбрать HLE. (по умолчанию LLE)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="28"/>
+        <source>Increases the amount of usable system memory to match a DECR console and more.
+Causes some software to behave differently than on retail hardware.</source>
+        <translation>Увеличивает объём доступной системной памяти до уровня консоли DECR и выше.
+Некоторые программы могут вести себя иначе, чем на реальном железе.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="29"/>
+        <source>Forces RSX pauses on SPU MFC_GETLLAR and SPU MFC_PUTLLUC operations.</source>
+        <translation>Принудительно приостанавливает RSX при операциях SPU MFC_GETLLAR и SPU MFC_PUTLLUC.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="30"/>
+        <source>Accurately processes SPU DMA operations.</source>
+        <translation>Точно обрабатывает операции SPU DMA.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="31"/>
+        <source>Legacy option. Fixup result vector values in Non-Java Mode in PPU LLVM.
+If unsure, do not modify this setting.</source>
+        <translation>Устаревшая опция. Исправляет значения результирующих векторов в режиме Non-Java в PPU LLVM.
+Если не уверены — не изменяйте этот параметр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="32"/>
+        <source>Use accurate double-precision FMA instructions in PPU and SPU backends.
+While disabling it might give a decent performance boost if your CPU doesn&apos;t support FMA, it may also introduce subtle bugs that otherwise do not occur.
+You shouldn&apos;t disable it if your CPU supports FMA.</source>
+        <translation>Использует точные FMA-инструкции двойной точности в PPU и SPU.
+Отключение может дать прирост производительности, если ваш CPU не поддерживает FMA, но может привести к трудноуловимым багам.
+Не отключайте, если ваш CPU поддерживает FMA.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="33"/>
+        <source>Fixup NaN results in vector instructions in PPU backends.
+If unsure, do not modify this setting.</source>
+        <translation>Исправляет значения NaN в векторных инструкциях PPU.
+Если не уверены — не изменяйте этот параметр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="34"/>
+        <source>Stop writing any logs after game startup. Don&apos;t use unless you believe it&apos;s necessary.</source>
+        <translation>Прекращает запись логов после запуска игры. Не используйте без необходимости.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="35"/>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="36"/>
+        <source>Initializes render target memory using vm memory.</source>
+        <translation>Инициализирует память рендер-таргетов через vm-память.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="37"/>
+        <source>Writes depth buffer values to vm memory.</source>
+        <translation>Записывает значения буфера глубины в vm-память.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="38"/>
+        <source>Obey RSX memory tiling configuration when writing GPU data to vm memory.
+This can fix graphics corruption observed when Read Color or Read Depth options are enabled.</source>
+        <translation>Соблюдает конфигурацию тайлинга памяти RSX при записи данных GPU в vm-память.
+Может исправить артефакты, возникающие при включённых опциях «Читать цвет» или «Читать глубину».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="39"/>
+        <source>Disables the loading and saving of shaders from and to the shader cache in the data directory.</source>
+        <translation>Отключает загрузку и сохранение шейдеров в кэш в папке данных.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="40"/>
+        <source>Allows the host GPU to synchronize with CELL directly. This incurs a performance penalty, but exposes the true state of GPU objects to the guest CPU. Can help eliminate visual noise and glitching at the cost of performance. Use with caution.</source>
+        <translation>Позволяет GPU хоста синхронизироваться непосредственно с CELL. Снижает производительность, но раскрывает истинное состояние объектов GPU для гостевого CPU. Помогает устранить визуальные артефакты ценой производительности. Используйте с осторожностью.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="41"/>
+        <source>Forces MSAA to use the host GPU&apos;s resolve capabilities for all sampling operations.
+This option incurs a performance penalty as well as the risk of visual artifacts but can yield crisper visuals when MSAA is enabled.</source>
+        <translation>Принудительно использует возможности разрешения GPU хоста для всех операций сэмплирования MSAA.
+Снижает производительность и может вызвать артефакты, но даёт более чёткое изображение при включённом MSAA.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="42"/>
+        <source>Disables the vertex cache.
+Might resolve missing or flickering graphics output.
+May degrade performance.</source>
+        <translation>Отключает кэш вершин.
+Может устранить пропадающую или мерцающую графику.
+Может снизить производительность.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="43"/>
+        <source>Force host memory management calls to be inlined instead of handled asynchronously.
+This can cause severe performance degradation and stuttering in some games.
+This option is only needed by developers to debug problems with texture cache memory protection.</source>
+        <translation>Принудительно встраивает вызовы управления памятью хоста вместо асинхронной обработки.
+Может вызвать значительное падение производительности и фризы в некоторых играх.
+Нужно только разработчикам для отладки проблем с защитой памяти кэша текстур.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="44"/>
+        <source>Disable SPU GETLLAR spin optimization.
+This can cause severe performance degradation and stuttering in many games.
+This option is only needed for a select number of games.</source>
+        <translation>Отключает оптимизацию спин-ожидания SPU GETLLAR.
+Может вызвать значительное падение производительности и фризы во многих играх.
+Нужно лишь для отдельных игр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="45"/>
+        <source>Enable SPU RdEventStat spin.
+This increases CPU usage, this setting is beneficial for high-threaded CPUs (12+) with select number of games.</source>
+        <translation>Включает спин-ожидание SPU RdEventStat.
+Увеличивает нагрузку на CPU; полезно для многопоточных CPU (12+) с отдельными играми.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="46"/>
+        <source>Changes ZCULL report synchronization behaviour. Experiment to find the best option for your game. Approximate mode is recommended for most games.
+· Precise is the most accurate to PS3 behaviour. Required for accurate visuals in some titles such as Demon&apos;s Souls and The Darkness.
+· Approximate is a much faster way to generate occlusion data which may not always match what the PS3 would generate. Works well with most PS3 games.
+· Relaxed changes the synchronization method completely and can greatly improve performance in some games or completely break others.</source>
+        <translation>Изменяет поведение синхронизации отчётов ZCULL. Экспериментируйте, чтобы найти лучший вариант для вашей игры. Режим «Приблизительно» рекомендуется для большинства игр.
+· Точно — наиболее точное соответствие поведению PS3. Требуется для корректной графики в некоторых играх, например Demon&apos;s Souls и The Darkness.
+· Приблизительно — значительно быстрее генерирует данные окклюзии, но может отличаться от PS3. Хорошо работает с большинством игр PS3.
+· Расслаблено — полностью меняет метод синхронизации; может сильно улучшить производительность в одних играх или сломать другие.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="47"/>
+        <source>Limits the maximum number of SPURS threads in each thread group.
+May improve performance in some cases, especially on systems with limited number of hardware threads.
+Limiting the number of threads is likely to cause crashes; it&apos;s recommended to keep this at the default value.</source>
+        <translation>Ограничивает максимальное количество потоков SPURS в каждой группе.
+Может улучшить производительность в некоторых случаях, особенно на системах с ограниченным числом аппаратных потоков.
+Ограничение потоков может вызвать вылеты; рекомендуется оставить значение по умолчанию.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="48"/>
+        <source>Changes the sleep period accuracy.
+&apos;As Host&apos; uses default accuracy of the underlying operating system, while &apos;All Timers&apos; attempts to improve it.
+&apos;Usleep Only&apos; limits the adjustments to usleep syscall only.
+Can affect performance in unexpected ways.</source>
+        <translation>Изменяет точность периода сна.
+«Как у хоста» — использует точность ОС по умолчанию, «Все таймеры» — пытается её улучшить.
+«Только Usleep» — ограничивает корректировки только системным вызовом usleep.
+Может непредсказуемо влиять на производительность.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="49"/>
+        <source>&quot;Fast&quot; is the least accurate setting, RSX does not emulate atomic FIFO buffer.
+&quot;Atomic&quot; benefits stability greatly in many games with little performance penalty.
+&quot;Atomic &amp; Ordered&quot; is the most accurate but it is the slowest and without much stability benefit in games.</source>
+        <translation>«Быстро» — наименее точный режим, RSX не эмулирует атомарный FIFO-буфер.
+«Атомарно» — значительно повышает стабильность во многих играх с небольшим снижением производительности.
+«Атомарно и упорядоченно» — самый точный, но и самый медленный, без значительного прироста стабильности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="50"/>
+        <source>Adjusts the frequency of vertical blanking signals that the emulator sends.
+Affects timing of events which rely on these signals.</source>
+        <translation>Регулирует частоту сигналов вертикального гашения (VBLANK).
+Влияет на тайминг событий, зависящих от этих сигналов.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="51"/>
+        <source>Multiplies the rate of VBLANK by 1000/1001 for values like 59.94Hz.
+Known to fix the rhythm game Space Channel 5 Part 2</source>
+        <translation>Умножает частоту VBLANK на 1000/1001 для значений вроде 59.94 Гц.
+Известно, что это исправляет ритм-игру Space Channel 5 Part 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="52"/>
+        <source>Changes the scale of emulated system time.
+Affects software which uses system time to calculate things such as dynamic timesteps.</source>
+        <translation>Изменяет масштаб эмулируемого системного времени.
+Влияет на программы, использующие системное время для вычисления динамических шагов времени.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="53"/>
+        <source>Controls how much time it takes for RSX to start processing after waking up by the Cell processor.
+Increasing wakeup delay improves stability, but very high values can lower RSX/GPU performance.
+It is recommend to adjust this at 20µs to 40µs increments until the best value for optimal stability is reached.</source>
+        <translation>Управляет временем запуска RSX после пробуждения процессором Cell.
+Увеличение задержки пробуждения повышает стабильность, но слишком большие значения снижают производительность RSX/GPU.
+Рекомендуется настраивать с шагом 20–40 мкс до достижения оптимальной стабильности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="54"/>
+        <source>Do not change this setting globally.
+Right-click a game in the game list and choose &quot;Configure&quot; instead.</source>
+        <translation>Не изменяйте этот параметр глобально.
+Вместо этого щёлкните правой кнопкой мыши по игре в списке и выберите «Настроить».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="55"/>
+        <source>Determines how to schedule GPU async compute jobs when using asynchronous streaming.
+Use &apos;Safe&apos; mode for more spec compliant behavior at the cost of some CPU overhead. This setting works with all devices.
+Use &apos;Fast&apos; to use a faster but hacky version. This option is internally disabled for NVIDIA GPUs due to causing GPU hangs.</source>
+        <translation>Определяет планирование асинхронных вычислительных задач GPU при потоковой передаче.
+Режим «Безопасно» — более корректное поведение ценой некоторых накладных расходов CPU. Работает со всеми устройствами.
+Режим «Быстро» — более быстрый, но менее надёжный вариант. Внутренне отключён для GPU NVIDIA из-за зависаний.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="56"/>
+        <source>Disables Fast Math for MSL shaders, which may violate the IEEE 754 standard.
+Disabling it may fix some artifacts, especially on Apple GPUs, at the cost of performance.</source>
+        <translation>Отключает Fast Math для шейдеров MSL, которые могут нарушать стандарт IEEE 754.
+Отключение может исправить артефакты, особенно на GPU Apple, ценой производительности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="57"/>
+        <source>When this mode is on, emulation exits when saving and the savestate file is concealed after its load, preventing reuse by RPCS3.
+This mode is like hibernation of emulation: if you don&apos;t want to be able to cheat using savestates when playing the game, consider using this mode.
+Do note that the savestate file is not gone completely, just ignored by RPCS3. You can manually relaunch it if needed.</source>
+        <translation>При включении этого режима эмуляция завершается при сохранении, а файл сохранения скрывается после загрузки, предотвращая повторное использование в RPCS3.
+Это похоже на режим гибернации: если вы не хотите читерить с помощью сохранений во время игры — используйте этот режим.
+Файл сохранения не удаляется, просто игнорируется RPCS3. При необходимости его можно запустить вручную.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="58"/>
+        <source>When this mode is on, SPU emulation prioritizes savestate compatibility, however, it may reduce performance slightly.
+When this mode is off, some games may not allow making a savestate and show an SPU pause error in the log.</source>
+        <translation>При включении этого режима эмуляция SPU приоритизирует совместимость с сохранениями, что может немного снизить производительность.
+При отключении некоторые игры могут не позволить создать сохранение и показать ошибку паузы SPU в логе.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="59"/>
+        <source>When this mode is on, savestates are loaded and paused on the first frame.
+This allows players to prepare for gameplay without being thrown into the action immediately.</source>
+        <translation>При включении этого режима сохранения загружаются и ставятся на паузу на первом кадре.
+Позволяет игроку подготовиться к игре, не попадая сразу в действие.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="60"/>
+        <source>When enabled, SPU performance is measured at runtime.
+Enable only at a developer&apos;s request because when enabled it reduces performance a bit by itself.</source>
+        <translation>При включении производительность SPU измеряется в реальном времени.
+Включайте только по запросу разработчика, так как само по себе снижает производительность.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="61"/>
+        <source>When enabled, Vulkan will try to use PCI-e resizable bar address space for GPU uploads of timing-sensitive data.
+This yields a massive performance win on NVIDIA cards when the base framerate is low.
+For games with very high framerates, this option can result in worse performance for all GPU vendors.
+</source>
+        <translation>При включении Vulkan попытается использовать адресное пространство PCI-e Resizable BAR для загрузки данных GPU.
+Даёт значительный прирост производительности на картах NVIDIA при низкой базовой частоте кадров.
+При очень высокой частоте кадров может ухудшить производительность для всех GPU.
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="62"/>
+        <source>Set the minimum log levels for any log channels.</source>
+        <translation>Устанавливает минимальный уровень логирования для каждого канала.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="66"/>
+        <source>Cubeb uses a cross-platform approach and supports audio buffering, so it is the recommended option.
+XAudio2 uses native Windows sounds system and is the next best alternative.</source>
+        <translation>Cubeb использует кроссплатформенный подход и поддерживает буферизацию звука — рекомендуемый вариант.
+XAudio2 использует нативную звуковую систему Windows и является следующим по предпочтению.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="67"/>
+        <source>Cubeb uses a cross-platform approach and supports audio buffering, so it is the recommended option.
+If it&apos;s not available, FAudio could be used instead.</source>
+        <translation>Cubeb использует кроссплатформенный подход и поддерживает буферизацию звука — рекомендуемый вариант.
+Если недоступен, можно использовать FAudio.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="68"/>
+        <source>Controls which PS3 audio API is used.
+Games use CellAudio, while VSH requires RSXAudio.</source>
+        <translation>Определяет используемый аудио API PS3.
+Игры используют CellAudio, VSH требует RSXAudio.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="69"/>
+        <source>Controls which avport is used to sample audio data from.</source>
+        <translation>Определяет avport для захвата аудиоданных.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="70"/>
+        <source>Controls which device is used by audio backend.</source>
+        <translation>Определяет устройство, используемое аудиобэкендом.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="71"/>
+        <source>Saves all audio as a raw wave file. If unsure, leave this unchecked.</source>
+        <translation>Сохраняет весь звук в файл формата WAV. Если не уверены — оставьте отключённым.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="72"/>
+        <source>Uses 16-bit audio samples instead of default 32-bit floating point.
+Use with buggy audio drivers if you have no sound or completely broken sound.</source>
+        <translation>Использует 16-битные сэмплы вместо стандартных 32-битных с плавающей точкой.
+Используйте при проблемных аудиодрайверах, если нет звука или он сильно искажён.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="73"/>
+        <source>Determines the sound format of the emulation.
+Configure this setting if you want to switch between stereo and surround sound.
+Changing these values requires a restart of the game.
+The manual setting will use your selected formats while the automatic setting will let the game choose from all available formats.</source>
+        <translation>Определяет звуковой формат эмуляции.
+Настройте, если хотите переключиться между стерео и объёмным звуком.
+Изменение требует перезапуска игры.
+Ручной режим использует выбранные форматы, автоматический позволяет игре выбирать из доступных.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="74"/>
+        <source>Determines the sound format of RPCS3.
+Use &apos;Auto&apos; to let RPCS3 decide the best format based on the audio device and the emulated audio format.</source>
+        <translation>Определяет звуковой формат RPCS3.
+Используйте «Авто», чтобы RPCS3 выбирал формат на основе аудиоустройства и эмулируемого формата.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="75"/>
+        <source>Controls the overall volume of the emulation.
+Values above 100% might reduce the audio quality.</source>
+        <translation>Управляет общей громкостью эмуляции.
+Значения выше 100% могут снизить качество звука.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="76"/>
+        <source>Enables audio buffering, which reduces crackle/stutter but increases audio latency.</source>
+        <translation>Включает буферизацию звука, что уменьшает треск и заикания, но увеличивает задержку.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="77"/>
+        <source>Target buffer duration in milliseconds.
+Higher values make the buffering algorithm&apos;s job easier, but may introduce noticeable audio latency.</source>
+        <translation>Целевая длительность буфера в миллисекундах.
+Большие значения облегчают работу алгоритма буферизации, но могут увеличить заметную задержку звука.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="78"/>
+        <source>Enables time stretching - requires buffering to be enabled.
+Reduces crackle/stutter further, but may cause a very noticeable reduction in audio quality on slower CPUs.</source>
+        <translation>Включает растяжение времени — требует включённой буферизации.
+Дополнительно уменьшает треск и заикания, но на медленных CPU может заметно снизить качество звука.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="79"/>
+        <source>Buffer fill level (in percentage) below which time stretching will start.</source>
+        <translation>Уровень заполнения буфера (в процентах), ниже которого начнётся растяжение времени.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="80"/>
+        <source>Standard should be used for most games.
+SingStar emulates a SingStar device and should be used with SingStar games.
+Real SingStar should only be used with a REAL SingStar device with SingStar games.
+Rocksmith should be used with a Rocksmith dongle.</source>
+        <translation>Стандартный подходит для большинства игр.
+SingStar эмулирует устройство SingStar и должен использоваться с играми SingStar.
+Real SingStar следует использовать только с реальным устройством SingStar.
+Rocksmith используется с донглом Rocksmith.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="84"/>
+        <source>Interpreter (slow). Try this if PPU Recompiler (LLVM) doesn&apos;t work.</source>
+        <translation>Интерпретатор (медленно). Попробуйте, если PPU Рекомпилятор (LLVM) не работает.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="85"/>
+        <source>Alternative interpreter (slow). May be faster than static interpreter. Try this if PPU Recompiler (LLVM) doesn&apos;t work.</source>
+        <translation>Альтернативный интерпретатор (медленно). Может быть быстрее статического. Попробуйте, если PPU Рекомпилятор (LLVM) не работает.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="86"/>
+        <source>Recompiles and caches the game&apos;s PPU code using the LLVM Recompiler once before running it for the first time.
+This is by far the fastest option and should always be used.
+Should you face compatibility issues, fall back to one of the Interpreters and retry.
+If unsure, use this option.</source>
+        <translation>Рекомпилирует и кэширует PPU-код игры с помощью LLVM Рекомпилятора один раз перед первым запуском.
+Это самый быстрый вариант, рекомендуется всегда использовать его.
+При проблемах с совместимостью переключитесь на один из интерпретаторов.
+Если не уверены — используйте этот вариант.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="87"/>
+        <source>Searches the game&apos;s directory and precompiles extra PPU and SPU modules during boot.
+If disabled, these modules will only be compiled when needed. Depending on the game, this might interrupt the gameplay unexpectedly and possibly frequently.
+Only disable this if you want to get ingame more quickly.</source>
+        <translation>Сканирует папку игры и предварительно компилирует дополнительные модули PPU и SPU при загрузке.
+При отключении модули компилируются по мере необходимости, что может прерывать игровой процесс.
+Отключайте только если хотите быстрее попасть в игру.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="88"/>
+        <source>Interpreter (slow). Try this if SPU Recompiler (LLVM) doesn&apos;t work.</source>
+        <translation>Интерпретатор (медленно). Попробуйте, если SPU Рекомпилятор (LLVM) не работает.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="89"/>
+        <source>Alternative interpreter (slow). May be faster than static interpreter. Try this if SPU Recompiler (LLVM) doesn&apos;t work.</source>
+        <translation>Альтернативный интерпретатор (медленно). Может быть быстрее статического. Попробуйте, если SPU Рекомпилятор (LLVM) не работает.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="90"/>
+        <source>Recompiles the game&apos;s SPU code using the ASMJIT Recompiler.
+This is the fast option with very good compatibility.
+If unsure, use this option.</source>
+        <translation>Рекомпилирует SPU-код игры с помощью ASMJIT Рекомпилятора.
+Быстрый вариант с очень хорошей совместимостью.
+Если не уверены — используйте этот вариант.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="91"/>
+        <source>Recompiles and caches the game&apos;s SPU code using the LLVM Recompiler before running which adds extra start-up time.
+This is the fastest option with very good compatibility.
+If you experience issues, use the ASMJIT Recompiler.</source>
+        <translation>Рекомпилирует и кэширует SPU-код игры с помощью LLVM Рекомпилятора перед запуском.
+Самый быстрый вариант с очень хорошей совместимостью.
+При проблемах используйте ASMJIT Рекомпилятор.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="92"/>
+        <source>Control accuracy to SPU float vectors processing.
+Fixes bugs in various games at the cost of performance.
+This setting is only applied when SPU Decoder is set to Dynamic or LLVM.</source>
+        <translation>Управляет точностью обработки векторов с плавающей точкой SPU.
+Исправляет ошибки в различных играх ценой производительности.
+Применяется только при декодере SPU в режиме Dynamic или LLVM.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="93"/>
+        <source>Control how RPCS3 utilizes the threads of your system.
+Each option heavily depends on the game and on your CPU. It&apos;s recommended to try each option to find out which performs the best.
+Changing the thread scheduler is not supported on CPUs with less than 12 threads.</source>
+        <translation>Управляет использованием потоков процессора в RPCS3.
+Каждый вариант сильно зависит от игры и CPU. Рекомендуется попробовать все варианты.
+Изменение планировщика не поддерживается на CPU с менее чем 12 потоками.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="94"/>
+        <source>Try to detect loop conditions in SPU kernels and use them as scheduling hints.
+Improves performance and reduces CPU usage.
+May cause severe audio stuttering in rare cases.</source>
+        <translation>Пытается обнаружить условия цикла в ядрах SPU и использовать их как подсказки планировщика.
+Улучшает производительность и снижает нагрузку на CPU.
+В редких случаях может вызвать сильные заикания звука.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="95"/>
+        <source>This option controls the SPU analyser, particularly the size of compiled units. The Mega and Giga modes may improve performance by tying smaller units together, decreasing the number of compiled units but increasing their size.
+Use the Safe mode for maximum compatibility.</source>
+        <translation>Управляет анализатором SPU, в частности размером компилируемых единиц. Режимы Mega и Giga могут улучшить производительность, объединяя небольшие единицы.
+Для максимальной совместимости используйте режим Safe.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="96"/>
+        <source>Some SPU stages are sensitive to race conditions and allowing a limited number at a time helps alleviate performance stalls.
+Setting this to a smaller value might improve performance and reduce stuttering in some games.
+Leave this on auto if performance is negatively affected when setting a small value.</source>
+        <translation>Некоторые стадии SPU чувствительны к состояниям гонки, ограничение их числа помогает избежать задержек.
+Меньшее значение может улучшить производительность и снизить фризы в некоторых играх.
+Оставьте на авто, если малые значения негативно влияют на производительность.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="97"/>
+        <source>Reduces CPU usage and power consumption, improving battery life on mobile devices. (0 means disabled)
+Higher values cause a more pronounced effect, but may cause audio or performance issues. A value of 50 or less is recommended.
+This option forces an FPS limit because it&apos;s active when framerate is stable.
+The lighter the game is on the hardware, the more power is saved by it. (until the preemption count barrier is reached)</source>
+        <translation>Снижает нагрузку на CPU и энергопотребление, увеличивая время работы от батареи. (0 — отключено)
+Большие значения усиливают эффект, но могут вызвать проблемы со звуком или производительностью. Рекомендуется не более 50.
+Принудительно ограничивает FPS, активно при стабильной частоте кадров)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="101"/>
+        <source>Leave this enabled unless you are a developer.</source>
+        <translation>Оставьте включённым, если вы не разработчик.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="102"/>
+        <source>Creates PPU logs.
+Only useful to developers.
+Never use this.</source>
+        <translation>Создаёт логи PPU.
+Полезно только разработчикам.
+Не используйте это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="103"/>
+        <source>Creates SPU logs.
+Only useful to developers.
+Never use this.</source>
+        <translation>Создаёт логи SPU.
+Полезно только разработчикам.
+Не используйте это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="104"/>
+        <source>Creates MFC logs.
+Only useful to developers.
+Never use this.</source>
+        <translation>Создаёт логи MFC.
+Полезно только разработчикам.
+Не используйте это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="105"/>
+        <source>Sets special MXCSR flags to debug errors in SSE operations.
+Only used in PPU thread when it&apos;s not precise.
+Only useful to developers.
+Never use this.</source>
+        <translation>Устанавливает специальные флаги MXCSR для отладки ошибок в операциях SSE.
+Используется только в потоке PPU в неточном режиме.
+Полезно только разработчикам.
+Не используйте это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="106"/>
+        <source>Accurately set Saturation Bit values in PPU backends.
+If unsure, do not modify this setting.</source>
+        <translation>Точно устанавливает биты насыщения в PPU.
+Если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="107"/>
+        <source>Respect Non-Java Mode Bit values for vector ops in PPU backends.
+If unsure, do not modify this setting.</source>
+        <translation>Соблюдает значения бита режима Non-Java для векторных операций в PPU.
+Если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="108"/>
+        <source>Accurately set NaN results in vector instructions in PPU backends.
+If unsure, do not modify this setting.</source>
+        <translation>Точно устанавливает значения NaN в векторных инструкциях PPU.
+Если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="109"/>
+        <source>Accurately set FPCC Bits in PPU backends.
+If unsure, do not modify this setting.</source>
+        <translation>Точно устанавливает биты FPCC в PPU.
+Если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="110"/>
+        <source>Accurately processes PPU DCBZ instruction.
+In addition, when combined with Accurate SPU DMA, SPU PUT cache line accesses will be processed atomically.</source>
+        <translation>Точно обрабатывает инструкцию PPU DCBZ.
+В сочетании с «Точным SPU DMA» доступы SPU PUT к строкам кэша обрабатываются атомарно.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="111"/>
+        <source>Forces delaying any odd MFC command, waits for at least 2 pending commands to execute them in a random order.
+Must be used with either SPU interpreters currently.
+Severely degrades performance! If unsure, don&apos;t use this option.</source>
+        <translation>Принудительно задерживает нечётные команды MFC, ожидая минимум 2 команды для выполнения в случайном порядке.
+Сейчас работает только с интерпретаторами SPU.
+Сильно снижает производительность! Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="112"/>
+        <source>Allows to hook some functions like &apos;memcpy&apos; replacing them with high-level implementations. May do nothing or break things. Experimental.</source>
+        <translation>Позволяет перехватывать некоторые функции, например «memcpy», заменяя их высокоуровневыми реализациями. Может ничего не делать или сломать. Экспериментально.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="113"/>
+        <source>Enables use of classic OpenGL buffers which allows capturing tools to work with RPCS3 e.g RenderDoc.
+Also allows Vulkan to use debug markers for nicer Renderdoc captures.
+If unsure, don&apos;t use this option.</source>
+        <translation>Включает классические буферы OpenGL, позволяя инструментам захвата работать с RPCS3 (например RenderDoc).
+Также позволяет Vulkan использовать отладочные маркеры для более удобных захватов RenderDoc.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="114"/>
+        <source>Only useful when debugging differences in GPU hardware.
+Not necessary for average users.
+If unsure, don&apos;t use this option.</source>
+        <translation>Полезно только при отладке различий в аппаратном обеспечении GPU.
+Обычным пользователям не нужно.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="115"/>
+        <source>Enables the selected API&apos;s inbuilt debugging functionality.
+Will cause severe performance degradation especially with Vulkan.
+Only useful to developers.
+If unsure, don&apos;t use this option.</source>
+        <translation>Включает встроенную отладку выбранного API.
+Вызывает сильное падение производительности, особенно с Vulkan.
+Полезно только разработчикам.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="116"/>
+        <source>Provides a graphical overlay of various debugging information.
+If unsure, don&apos;t use this option.</source>
+        <translation>Отображает графический оверлей с различной отладочной информацией.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="117"/>
+        <source>Provides a graphical overlay with pad input values for player 1.
+This is only shown if the debug overlay is disabled.
+If unsure, don&apos;t use this option.</source>
+        <translation>Отображает оверлей с состоянием ввода геймпада для игрока 1.
+Показывается только если отладочный оверлей отключён.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="118"/>
+        <source>Provides a graphical overlay with mouse input values.
+This is only shown if the other debug overlays are disabled.
+If unsure, don&apos;t use this option.</source>
+        <translation>Отображает оверлей с состоянием мыши.
+Показывается только если другие отладочные оверлеи отключены.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="119"/>
+        <source>Dump game shaders to file. Only useful to developers.
+If unsure, don&apos;t use this option.</source>
+        <translation>Сохраняет шейдеры игры в файл. Полезно только разработчикам.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="120"/>
+        <source>Disables running occlusion queries. Minor to moderate performance boost.
+Might introduce issues with broken occlusion e.g missing geometry and extreme pop-in.</source>
+        <translation>Отключает occlusion queries. Небольшой или умеренный прирост производительности.
+Может вызвать проблемы: пропадающая геометрия и сильный pop-in.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="121"/>
+        <source>Disables all video output and PS3 graphical rendering.
+Its only use case is to evaluate performance on CELL for development.</source>
+        <translation>Отключает весь видеовывод и графическую отрисовку PS3.
+Используется только для оценки производительности CELL в целях разработки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="122"/>
+        <source>Forces emulation of all blit and image manipulation operations on the CPU.
+Requires &apos;Write Color Buffers&apos; option to also be enabled in most cases to avoid missing graphics.
+Significantly degrades performance but is more accurate in some cases.
+This setting overrides the &apos;GPU texture scaling&apos; option.</source>
+        <translation>Принудительно эмулирует все операции блиттинга и обработки изображений на CPU.
+В большинстве случаев требует включения «Записать цветовые буферы» во избежание пропадания графики.
+Значительно снижает производительность, но в некоторых случаях точнее.
+Этот параметр переопределяет опцию «Масштабирование текстур GPU».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="123"/>
+        <source>Disables the custom Vulkan memory allocator and reverts to direct calls to VkAllocateMemory/VkFreeMemory.</source>
+        <translation>Отключает пользовательский аллокатор памяти Vulkan и возвращается к прямым вызовам VkAllocateMemory/VkFreeMemory.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="124"/>
+        <source>Disables RSX FIFO optimizations completely. Draws are processed as they are received by the DMA puller.</source>
+        <translation>Полностью отключает оптимизации RSX FIFO. Команды отрисовки обрабатываются по мере получения DMA.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="125"/>
+        <source>Force all texture transfer, scaling and conversion operations on the GPU.
+May cause texture corruption in some cases.</source>
+        <translation>Принудительно выполняет все операции переноса, масштабирования и конвертации текстур на GPU.
+Может вызвать повреждение текстур в некоторых случаях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="126"/>
+        <source>Forces texture flushing even in situations where it is not necessary/correct. Known to cause visual artifacts, but useful for debugging certain texture cache issues.</source>
+        <translation>Принудительно сбрасывает кэш текстур даже когда это не нужно или неверно. Вызывает артефакты, но полезно для отладки проблем кэша текстур.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="127"/>
+        <source>Sets the 3D stereo rendering mode (only available in custom configurations with a default resolution of 720p).
+Anaglyph uses different colors for each eye, which can then be filtered with certain glasses.
+Side-by-Side is more commonly supported by VR viewer apps.
+Over-Under is closer to the native stereo output, but less commonly supported.</source>
+        <translation>Устанавливает режим стереоскопического 3D-рендеринга (только в пользовательских конфигурациях с разрешением 720p по умолчанию).
+Анаглиф использует разные цвета для каждого глаза, фильтруемые специальными очками.
+Side-by-Side чаще поддерживается приложениями VR.
+Over-Under ближе к нативному стереовыводу, но поддерживается реже.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="128"/>
+        <source>When enabled, PPU atomic operations will operate on entire cache line data, as opposed to a single 64bit block of memory when disabled.
+Numerical values control whether or not to enable the accurate version based on the atomic operation&apos;s length.</source>
+        <translation>При включении PPU атомарные операции работают с данными всей строки кэша, а не с блоком 64 бит.
+Числовые значения определяют, включать ли точный режим в зависимости от длины атомарной операции.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="129"/>
+        <source>Measure certain events and print a chart after the emulator is stopped. Don&apos;t enable if not asked to.</source>
+        <translation>Измеряет определённые события и выводит диаграмму после остановки эмулятора. Не включайте без необходимости.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="130"/>
+        <source>Affects maximum amount of PPU threads running concurrently, the value of 1 has very low compatibility with games.
+2 is the default, if unsure do not modify this setting.</source>
+        <translation>Влияет на максимальное количество одновременно работающих потоков PPU. Значение 1 имеет очень низкую совместимость с играми.
+2 — по умолчанию; если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="131"/>
+        <source>Disables use of hardware-native color-space remapping formats such as _sRGB and _SNORM suffixes.
+Disabling this option increases accuracy compared to PS3 but can also introduce some noise due to how the software emulation works.</source>
+        <translation>Отключает аппаратные форматы перекодирования цветового пространства с суффиксами _sRGB и _SNORM.
+Отключение повышает точность по сравнению с PS3, но может вносить шум из-за программной эмуляции.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="135"/>
+        <source>Activate Feral Interactive&apos;s GameMode.
+This is a series of CPU and GPU optimizations and can potentially benefit game performance on some systems.</source>
+        <translation>Активирует GameMode от Feral Interactive.
+Это набор оптимизаций CPU и GPU, потенциально улучшающих производительность игр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="136"/>
+        <source>This requires Feral Interactive&apos;s GameMode to be installed.
+GameMode is a series of CPU and GPU optimizations and can potentially benefit game performance on some systems.
+To install GameMode for your specific Linux distribution, go to the GitHub page:https://github.com/FeralInteractive/gamemode.</source>
+        <translation>Требуется установленный GameMode от Feral Interactive.
+GameMode — набор оптимизаций CPU и GPU, потенциально улучшающих производительность.
+Для установки GameMode на вашем дистрибутиве Linux перейдите на страницу GitHub: https://github.com/FeralInteractive/gamemode.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="137"/>
+        <source>Automatically close RPCS3 when closing a game, or when a game closes itself.</source>
+        <translation>Автоматически закрывает RPCS3 при закрытии игры или когда игра завершается сама.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="138"/>
+        <source>Automatically pause emulation when RPCS3 loses its focus or the application is inactive in order to save power and reduce CPU usage.
+Do note that emulation pausing in general is not perfect and may not be compatible with all games.
+Although it currently also pauses gameplay, it is not recommended to rely on it as this behavior may be changed in the future and it is not the purpose of this setting.</source>
+        <translation>Автоматически приостанавливает эмуляцию, когда RPCS3 теряет фокус или приложение неактивно, для экономии CPU.
+Пауза эмуляции несовершенна и может быть несовместима со всеми играми.
+Хотя сейчас это также приостанавливает геймплей, не рекомендуется на это полагаться.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="139"/>
+        <source>Automatically puts the game window in fullscreen.
+Double click on the game window or press Alt+Enter to toggle fullscreen and windowed mode.</source>
+        <translation>Автоматически переводит окно игры в полноэкранный режим.
+Дважды щёлкните по окну игры или нажмите Alt+Enter для переключения между полноэкранным и оконным режимами.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="140"/>
+        <source>Prevent the display from sleeping while a game is running.
+This requires the org.freedesktop.ScreenSaver D-Bus service on Linux.
+This option will be disabled if the current platform does not support display sleep control.</source>
+        <translation>Предотвращает отключение экрана во время игры.
+Требуется D-Bus сервис org.freedesktop.ScreenSaver на Linux.
+Опция будет недоступна, если платформа не поддерживает управление сном экрана.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="141"/>
+        <source>Configure the game window title.
+Changing this and/or adding the framerate may cause buggy or outdated recording software to not notice RPCS3.</source>
+        <translation>Настраивает заголовок окна игры.
+Изменение заголовка и/или добавление частоты кадров может привести к тому, что устаревшее ПО для записи не обнаружит RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="142"/>
+        <source>Automatically resizes the game window on boot.
+This does not change the internal game resolution.</source>
+        <translation>Автоматически изменяет размер окна игры при запуске.
+Не влияет на внутреннее разрешение игры.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="143"/>
+        <source>Show trophy pop-ups when a trophy is unlocked.</source>
+        <translation>Показывает всплывающие уведомления при получении трофея.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="144"/>
+        <source>Show RPCN friend list pop-ups.</source>
+        <translation>Показывает всплывающие уведомления списка друзей RPCN.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="145"/>
+        <source>Disables the activation of fullscreen mode per double-click while the game screen is active.
+Check this if you want to play with mouse and keyboard (for example with UCR).</source>
+        <translation>Отключает переход в полноэкранный режим по двойному щелчку.
+Включите, если хотите играть с мышью и клавиатурой (например с UCR).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="146"/>
+        <source>Disables keyboard hotkeys such as Ctrl+S, Ctrl+E, Ctrl+R, Ctrl+P while the game screen is active.
+This does not include Ctrl+L (hide and lock mouse) and Alt+Enter (toggle fullscreen).
+Check this if you want to play with mouse and keyboard.</source>
+        <translation>Отключает горячие клавиши Ctrl+S, Ctrl+E, Ctrl+R, Ctrl+P во время игры.
+Не включает Ctrl+L (скрыть/заблокировать мышь) и Alt+Enter (полноэкранный режим).
+Включите, если хотите играть с мышью и клавиатурой.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="147"/>
+        <source>Limits the maximum number of threads used for the initial PPU and SPU module compilation.
+Lower this in order to increase performance of other open applications.
+The default uses all available threads.</source>
+        <translation>Ограничивает максимальное число потоков для первоначальной компиляции модулей PPU и SPU.
+Уменьшите, чтобы повысить производительность других приложений.
+По умолчанию используются все доступные потоки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="148"/>
+        <source>Shows the mouse cursor when the fullscreen mode is active.
+Currently this may not work every time.</source>
+        <translation>Показывает курсор мыши в полноэкранном режиме.
+В данный момент может работать не всегда.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="149"/>
+        <source>Locks the mouse cursor to the center when the fullscreen mode is active.</source>
+        <translation>Фиксирует курсор мыши по центру в полноэкранном режиме.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="150"/>
+        <source>Hides the mouse cursor if no mouse movement is detected for the configured time.</source>
+        <translation>Скрывает курсор мыши, если в течение заданного времени не обнаружено движения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="151"/>
+        <source>Shows &apos;Compiling shaders&apos; hint using the native overlay.</source>
+        <translation>Показывает подсказку «Компиляция шейдеров» через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="152"/>
+        <source>Shows &apos;Compiling PPU modules&apos; hint using the native overlay.</source>
+        <translation>Показывает подсказку «Компиляция модулей PPU» через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="153"/>
+        <source>Shows autosave/autoload hint using the native overlay.</source>
+        <translation>Показывает подсказку автосохранения/автозагрузки через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="154"/>
+        <source>Shows pressure intensity toggle hint using the native overlay.</source>
+        <translation>Показывает подсказку переключения интенсивности нажатия через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="155"/>
+        <source>Shows analog limiter toggle hint using the native overlay.</source>
+        <translation>Показывает подсказку переключения ограничителя аналога через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="156"/>
+        <source>Shows mouse and keyboard toggle hint using the native overlay.</source>
+        <translation>Показывает подсказку переключения мыши и клавиатуры через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="157"/>
+        <source>Shows screenshot and recording hints using the native overlay.</source>
+        <translation>Показывает подсказки скриншота и записи через нативный оверлей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="158"/>
+        <source>Enables use of native HUD within the game window that can interact with game controllers.
+When disabled, regular Qt dialogs are used instead.
+Currently, the on-screen keyboard only supports the English key layout.</source>
+        <translation>Включает нативный HUD в окне игры с поддержкой геймпадов.
+При отключении используются стандартные диалоги Qt.
+Экранная клавиатура пока поддерживает только английскую раскладку.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="159"/>
+        <source>Enables recording with overlays.
+This also affects screenshots.</source>
+        <translation>Включает запись с оверлеями.
+Также влияет на скриншоты.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="160"/>
+        <source>When enabled, opening the home menu will also pause emulation.
+While most games pause themselves while the home menu is shown, some do not.
+In that case it can be helpful to pause the emulation whenever the home menu is open.</source>
+        <translation>При включении открытие домашнего меню также приостанавливает эмуляцию.
+Большинство игр сами ставятся на паузу при открытии меню, но некоторые — нет.
+В таком случае полезно включить паузу эмуляции при открытии меню.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="162"/>
+        <source>Enables or disables the performance overlay.</source>
+        <translation>Включает или отключает оверлей производительности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="163"/>
+        <source>Enables or disables the framerate graph.</source>
+        <translation>Включает или отключает график частоты кадров.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="164"/>
+        <source>Enables or disables the frametime graph.</source>
+        <translation>Включает или отключает график времени кадра.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="165"/>
+        <source>Sets the amount of datapoints used in the framerate graph.</source>
+        <translation>Задаёт количество точек данных на графике частоты кадров.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="166"/>
+        <source>Sets the amount of datapoints used in the frametime graph.</source>
+        <translation>Задаёт количество точек данных на графике времени кадра.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="167"/>
+        <source>Sets the on-screen position (quadrant) of the performance overlay.</source>
+        <translation>Задаёт положение на экране (квадрант) оверлея производительности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="168"/>
+        <source>Controls the amount of information displayed on the performance overlay.</source>
+        <translation>Управляет количеством информации на оверлее производительности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="169"/>
+        <source>Sets the time interval in which the performance overlay is being updated (measured in milliseconds).
+Setting this to 16 milliseconds will refresh the performance overlay at roughly 60Hz.
+The performance overlay refresh rate does not affect the frame graph statistics and can only be as fast as the current game allows.</source>
+        <translation>Задаёт интервал обновления оверлея производительности (в миллисекундах).
+Значение 16 мс обновляет оверлей примерно со скоростью 60 Гц.
+Частота обновления оверлея не влияет на статистику графика кадров.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="170"/>
+        <source>Sets the font size of the performance overlay (measured in pixels).</source>
+        <translation>Задаёт размер шрифта оверлея производительности (в пикселях).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="171"/>
+        <source>Sets the opacity of the performance overlay (measured in %).</source>
+        <translation>Задаёт прозрачность оверлея производительности (в %).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="172"/>
+        <source>Sets the horizontal distance to the screen border relative to the screen quadrant (measured in pixels).</source>
+        <translation>Задаёт горизонтальный отступ от края экрана относительно квадранта (в пикселях).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="173"/>
+        <source>Sets the vertical distance to the screen border relative to the screen quadrant (measured in pixels).</source>
+        <translation>Задаёт вертикальный отступ от края экрана относительно квадранта (в пикселях).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="174"/>
+        <source>Centers the performance overlay horizontally and overrides the horizontal margin.</source>
+        <translation>Центрирует оверлей по горизонтали, игнорируя горизонтальный отступ.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="175"/>
+        <source>Centers the performance overlay vertically and overrides the vertical margin.</source>
+        <translation>Центрирует оверлей по вертикали, игнорируя вертикальный отступ.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="177"/>
+        <source>Shows a background image during the native shader loading dialog/loading screen.
+By default the used image will be &lt;gamedir&gt;/PS3_GAME/PIC1.PNG.</source>
+        <translation>Показывает фоновое изображение в нативном диалоге загрузки шейдеров.
+По умолчанию используется &lt;gamedir&gt;/PS3_GAME/PIC1.PNG.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="178"/>
+        <source>Changes the background image darkening effect strength of the native shader loading dialog.
+This may be used to improve readability and/or aesthetics.</source>
+        <translation>Изменяет интенсивность затемнения фонового изображения в диалоге загрузки шейдеров.
+Может использоваться для улучшения читаемости и/или эстетики.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="179"/>
+        <source>Changes the background image blur effect strength of the native shader loading dialog.
+This may be used to improve readability and/or aesthetics.</source>
+        <translation>Изменяет интенсивность размытия фонового изображения в диалоге загрузки шейдеров.
+Может использоваться для улучшения читаемости и/или эстетики.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="183"/>
+        <source>Vulkan is the fastest renderer. OpenGL is the most accurate renderer.
+If unsure, use Vulkan. Should you have any compatibility issues, fall back to OpenGL.</source>
+        <translation>Vulkan — самый быстрый рендерер. OpenGL — наиболее точный.
+Если не уверены — используйте Vulkan. При проблемах с совместимостью переключитесь на OpenGL.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="184"/>
+        <source>This setting will be ignored if the Resolution Scale is set to anything other than 100%!
+Leave this on 1280x720. Every PS3 game is compatible with this resolution.
+Only use 1920x1080 if the game supports it.
+Rarely due to emulation bugs some games will only render at low resolutions like 480p.</source>
+        <translation>Этот параметр игнорируется, если масштаб разрешения не равен 100%!
+Оставьте 1280x720. Все игры PS3 совместимы с этим разрешением.
+Используйте 1920x1080 только если игра поддерживает его.
+Из-за ошибок эмуляции некоторые игры могут рендерить только в низком разрешении (480p).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="185"/>
+        <source>On multi GPU systems select which GPU to use in RPCS3 when using Vulkan.
+This is not needed when using OpenGL.</source>
+        <translation>На системах с несколькими GPU выбирает, какой GPU использовать в RPCS3 при работе с Vulkan.
+Не нужно при использовании OpenGL.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="186"/>
+        <source>Leave this on 16:9 unless you have a 4:3 monitor.</source>
+        <translation>Оставьте 16:9, если у вас не монитор 4:3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="187"/>
+        <source>Off is the fastest option.
+Using the frame limiter will add extra overhead and slow down the game. However, some games will crash if the framerate is too high.
+PS3 native should only be used if Auto is not working correctly as it can introduce frame-pacing issues.
+Infinite adds a positive feedback loop which adds another vblank signal per frame allowing more games to be fps limitless.
+Experienced users with need of other frame limits should use the setting &quot;Second Frame Limit&quot; in the configuration file.</source>
+        <translation>Отключено — самый быстрый вариант.
+Лимитер кадров добавляет накладные расходы и замедляет игру. Однако некоторые игры вылетают при слишком высоком FPS.
+Native PS3 следует использовать только если Auto не работает корректно, так как может вызвать проблемы с синхронизацией кадров.
+Infinite добавляет дополнительный сигнал vblank на кадр, позволяя большему числу игр работать без ограничения FPS.
+Опытные пользователи, которым нужны другие ограничения, могут использовать параметр «Second Frame Limit» в файле конфигурации.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="188"/>
+        <source>Emulate PS3 multisampling layout.
+Can fix some otherwise difficult to solve graphics glitches.
+Low to moderate performance hit depending on your GPU hardware.</source>
+        <translation>Эмулирует схему мультисэмплинга PS3.
+Может исправить трудноустранимые графические артефакты.
+Небольшое или умеренное снижение производительности в зависимости от GPU.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="189"/>
+        <source>Higher values increase sharpness of textures on sloped surfaces at the cost of GPU resources.
+Modern GPUs can handle this setting just fine, even at 16x.
+Keep this on Automatic if you want to use the original setting used by a real PS3.</source>
+        <translation>Более высокие значения увеличивают чёткость текстур на наклонных поверхностях ценой ресурсов GPU.
+Современные GPU легко справляются с этим, даже при 16x.
+Оставьте Автоматически, чтобы использовать настройку реальной PS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="190"/>
+        <source>Scales the game&apos;s resolution by the given percentage.
+The base resolution is always 1280x720.
+Set this value to 100% if you want to use the normal Resolution options.
+Values below 100% will usually not improve performance.</source>
+        <translation>Масштабирует разрешение игры на заданный процент.
+Базовое разрешение всегда 1280x720.
+Установите 100%, чтобы использовать обычные параметры разрешения.
+Значения ниже 100% как правило не улучшают производительность.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="191"/>
+        <source>Only framebuffers greater than this size will be upscaled.
+Increasing this value might fix problems with missing graphics when upscaling, especially when Write Color Buffers is enabled.
+If unsure, don&apos;t change this option.</source>
+        <translation>Масштабируются только фреймбуферы больше этого размера.
+Увеличение значения может исправить пропадание графики при масштабировании, особенно при включённом «Записать цветовые буферы».
+Если не уверены — не изменяйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="192"/>
+        <source>Enable this option if you get missing graphics or broken lighting ingame.
+Might degrade performance and introduce stuttering in some cases.
+Required for Demon&apos;s Souls.</source>
+        <translation>Включите, если в игре пропадает графика или освещение работает неправильно.
+Может снизить производительность и вызвать фризы в некоторых случаях.
+Требуется для Demon&apos;s Souls.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="193"/>
+        <source>By having this off you might obtain a higher framerate at the cost of tearing artifacts in the game.</source>
+        <translation>При отключении можно получить более высокий FPS ценой разрывов изображения в игре.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="194"/>
+        <source>Enforces strict compliance to the API specification.
+Might result in degraded performance in some games.
+Can resolve rare cases of missing graphics and flickering.
+If unsure, don&apos;t use this option.</source>
+        <translation>Требует строгого соответствия спецификации API.
+Может снизить производительность в некоторых играх.
+Может устранить редкие случаи пропадания графики и мерцания.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="195"/>
+        <source>Overrides the aspect ratio and stretches the image to the full display area.</source>
+        <translation>Игнорирует соотношение сторон и растягивает изображение на весь экран.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="196"/>
+        <source>Offloads some RSX operations to a secondary thread.
+Improves performance for high-core processors.
+May cause slowdown in weaker CPUs due to the extra worker thread load.</source>
+        <translation>Переносит часть операций RSX на вторичный поток.
+Улучшает производительность на многоядерных процессорах.
+Может замедлить работу на слабых CPU из-за дополнительной нагрузки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="198"/>
+        <source>Disables asynchronous shader compilation.
+Fixes missing graphics while shaders are compiling but introduces severe stuttering or lag.
+Use this if you do not want to deal with graphics pop-in, or for testing before filing any bug reports.</source>
+        <translation>Отключает асинхронную компиляцию шейдеров.
+Устраняет пропадание графики во время компиляции, но вызывает сильные фризы.
+Используйте, если не хотите видеть pop-in графики, или для тестирования перед отправкой баг-репортов.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="199"/>
+        <source>This is the recommended option.
+If a shader is not found in the cache, nothing will be rendered for this shader until it has compiled.
+You may experience graphics pop-in.</source>
+        <translation>Рекомендуемый вариант.
+Если шейдер не найден в кэше, он не будет отрисован до завершения компиляции.
+Возможен pop-in графики.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="200"/>
+        <source>Hybrid rendering mode.
+If a shader is not found in the cache, the interpreter will be used to render approximated graphics for this shader until it has compiled.</source>
+        <translation>Гибридный режим рендеринга.
+Если шейдер не найден в кэше, интерпретатор используется для приблизительной отрисовки до завершения компиляции.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="201"/>
+        <source>All rendering is handled by the interpreter with no attempt to compile native shaders.
+This mode is very slow and experimental.</source>
+        <translation>Весь рендеринг выполняется интерпретатором без компиляции нативных шейдеров.
+Режим очень медленный и экспериментальный.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="202"/>
+        <source>Number of threads to use for the shader compiler backend.
+Only has an impact when shader mode is set to one of the asynchronous modes.</source>
+        <translation>Количество потоков для бэкенда компилятора шейдеров.
+Влияет только при асинхронных режимах шейдеров.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="203"/>
+        <source>Controls the precision level of generated shaders. Low precision generates much faster code depending on the hardware, but can sometimes generate minor visual glitches or flicker.</source>
+        <translation>Управляет уровнем точности генерируемых шейдеров. Низкая точность генерирует более быстрый код на некотором железе, но может вызывать незначительные артефакты или мерцание.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="205"/>
+        <source>Stream textures to GPU in parallel with 3D rendering using asynchronous compute.
+Can improve performance on more powerful GPUs that have spare headroom.
+Only works with Vulkan renderer and greatly benefits from having MTRSX enabled if you have a capable CPU.</source>
+        <translation>Передаёт текстуры на GPU параллельно с 3D-рендерингом через асинхронные вычисления.
+Может улучшить производительность на мощных GPU с запасом ресурсов.
+Работает только с Vulkan; значительно выигрывает от включённого MTRSX на мощном CPU.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="206"/>
+        <source>Controls which fullscreen mode RPCS3 requests from drivers when using Vulkan renderer.
+Automatic will let the driver choose an appropriate mode, while the other options will hint the drivers on whether they should use exclusive or borderless fullscreen.
+Using Prefer borderless fullscreen option can help if you have issues with streaming RPCS3 gameplay or if your system incorrectly enables HDR mode when using fullscreen.</source>
+        <translation>Определяет режим полноэкранного отображения, запрашиваемый у драйверов при использовании Vulkan.
+Автоматически — драйвер выбирает подходящий режим; остальные варианты подсказывают, использовать ли эксклюзивный или безрамочный режим.
+Режим «Предпочитать безрамочный» поможет при проблемах со стримингом или если система ошибочно включает HDR в полноэкранном режиме.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="208"/>
+        <source>Final image filtering. Nearest applies no filtering, Bilinear smooths the image, and FidelityFX Super Resolution enhances upscaled images.
+If the game is rendering at an internal resolution lower than your window resolution, FidelityFX will handle the upscale.
+FidelityFX can cause visual artifacts.
+FidelityFX does not work with stereo 3D output for now.</source>
+        <translation>Фильтрация итогового изображения. Nearest — без фильтрации, Bilinear — сглаживание, FidelityFX Super Resolution — улучшение масштабированных изображений.
+Если внутреннее разрешение игры ниже разрешения окна, FidelityFX обработает масштабирование.
+FidelityFX может вызывать артефакты.
+FidelityFX пока не работает со стереоскопическим 3D.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="209"/>
+        <source>Control the sharpening strength applied by FidelityFX Super Resolution. Higher values will give sharper output but may introduce artifacts.</source>
+        <translation>Управляет интенсивностью повышения резкости в FidelityFX Super Resolution. Более высокие значения дают более чёткое изображение, но могут вызвать артефакты.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="211"/>
+        <source>Changes Texture sampling accuracy. (Small changes have a big effect.)
+Avoid using values outside the range of -12 to +12 if you&apos;re unsure.
+-3 to +3 is plenty for most usecases</source>
+        <translation>Изменяет точность сэмплирования текстур. (Небольшие изменения оказывают большой эффект.)
+Если не уверены — не выходите за диапазон от -12 до +12.
+Для большинства случаев достаточно значений от -3 до +3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="215"/>
+        <source>Sets the maximum amount of blocks that the log can display.
+This usually equals the number of lines.
+Set 0 in order to remove the limit.</source>
+        <translation>Задаёт максимальное количество блоков в логе.
+Обычно равно числу строк.
+Установите 0 для снятия ограничения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="216"/>
+        <source>Sets the maximum amount of blocks that the TTY can display.
+This usually equals the number of lines.
+Set 0 in order to remove the limit.</source>
+        <translation>Задаёт максимальное количество блоков в TTY.
+Обычно равно числу строк.
+Установите 0 для снятия ограничения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="217"/>
+        <source>Changes the overall look of RPCS3.
+Choose a stylesheet and click Apply to change between styles.</source>
+        <translation>Изменяет внешний вид RPCS3.
+Выберите стиль и нажмите «Применить».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="218"/>
+        <source>Shows the initial welcome screen upon starting RPCS3.</source>
+        <translation>Показывает приветственный экран при запуске RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="219"/>
+        <source>Shows a confirmation dialog when the game window is being closed.</source>
+        <translation>Показывает диалог подтверждения при закрытии окна игры.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="220"/>
+        <source>Shows a confirmation dialog when a game was booted while another game is running.</source>
+        <translation>Показывает диалог подтверждения при запуске игры, когда другая уже запущена.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="221"/>
+        <source>Shows a dialog when packages were installed successfully.</source>
+        <translation>Показывает диалог при успешной установке пакетов.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="222"/>
+        <source>Shows a dialog when firmware was installed successfully.</source>
+        <translation>Показывает диалог при успешной установке прошивки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="223"/>
+        <source>Shows a dialog when obsolete settings were found.</source>
+        <translation>Показывает диалог при обнаружении устаревших настроек.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="224"/>
+        <source>Shows a dialog in the game pad configuration when the same button was assigned twice.</source>
+        <translation>Показывает диалог в настройке геймпада при двойном назначении одной кнопки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="225"/>
+        <source>Shows a dialog when RPCS3 is ready to restart after an update.</source>
+        <translation>Показывает диалог, когда RPCS3 готов перезапуститься после обновления.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="226"/>
+        <source>Checks if an update is available on startup and asks if you want to update.
+If &quot;Automatic&quot; is selected, the update will run automatically without user confirmation.
+If &quot;Background&quot; is selected, the check is done silently in the background and a new download option is shown in the top right corner of the menu if a new version was found.</source>
+        <translation>Проверяет наличие обновлений при запуске и предлагает обновиться.
+При выборе «Автоматически» обновление запускается без подтверждения.
+При выборе «В фоне» проверка выполняется тихо, а кнопка загрузки появляется в правом верхнем углу меню.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="227"/>
+        <source>Enables use of Discord Rich Presence to show what game you are playing on Discord.
+Requires a restart of RPCS3 to completely close the connection.</source>
+        <translation>Включает Discord Rich Presence для отображения текущей игры в Discord.
+Для полного закрытия соединения требуется перезапуск RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="228"/>
+        <source>Tell your friends what you are doing.</source>
+        <translation>Расскажите друзьям, чем вы занимаетесь.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="229"/>
+        <source>Prioritize custom user interface colors over properties set in stylesheet.</source>
+        <translation>Приоритизирует пользовательские цвета интерфейса над свойствами из таблицы стилей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="230"/>
+        <source>This is the ID used for hardware statistics.
+It should only be reset if you change your hardware configuration or if you copied RPCS3 to another PC.</source>
+        <translation>Это ID для статистики оборудования.
+Сбрасывайте только при смене конфигурации железа или переносе RPCS3 на другой ПК.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="231"/>
+        <source>Use the game pad that is configured for player 1 to navigate in the GUI.</source>
+        <translation>Использует геймпад игрока 1 для навигации в интерфейсе.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="232"/>
+        <source>Keep control over pad navigation if RPCS3 is not the active window.</source>
+        <translation>Сохраняет управление навигацией геймпадом, даже если RPCS3 не является активным окном.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="236"/>
+        <source>Single-threaded: All pad handlers run on the same thread sequentially.
+Multi-threaded: Each pad handler has its own thread.
+Only use multi-threaded if you can spare the extra threads.</source>
+        <translation>Однопоточный: все обработчики геймпадов работают последовательно в одном потоке.
+Многопоточный: каждый обработчик имеет собственный поток.
+Используйте многопоточный только если у вас есть свободные потоки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="237"/>
+        <source>Shows all configured pads as always connected ingame even if they are physically disconnected.</source>
+        <translation>Отображает все настроенные геймпады как постоянно подключённые в игре, даже если они физически отключены.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="238"/>
+        <source>Some games support native keyboard input.
+Basic will work in these cases.</source>
+        <translation>Некоторые игры поддерживают нативный ввод с клавиатуры.
+Вариант «Базовый» будет работать в таких случаях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="239"/>
+        <source>Some games support native mouse input.
+Basic or Raw will work in these cases.</source>
+        <translation>Некоторые игры поддерживают нативный ввод мыши.
+Варианты «Базовый» или «Raw» будут работать в таких случаях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="240"/>
+        <source>Currently only used for cellMusic emulation.
+Select Qt to use the default output device of your operating system.
+This may not be able to play all audio formats.</source>
+        <translation>Используется только для эмуляции cellMusic.
+Выберите Qt для использования устройства вывода по умолчанию вашей ОС.
+Может не поддерживать все аудиоформаты.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="241"/>
+        <source>Select Qt Camera to use the default camera device of your operating system.</source>
+        <translation>Выберите Qt Camera для использования камеры по умолчанию вашей ОС.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="242"/>
+        <source>Depending on the game, you may need to select a specific camera type.</source>
+        <translation>В зависимости от игры может потребоваться выбрать конкретный тип камеры.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="243"/>
+        <source>Flips the camera image either horizontally, vertically, or on both axes.</source>
+        <translation>Отражает изображение камеры по горизонтали, вертикали или обеим осям.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="244"/>
+        <source>Select the camera that you want to use during gameplay.</source>
+        <translation>Выберите камеру для использования во время игры.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="245"/>
+        <source>PlayStation Move support.
+Fake: Experimental! This maps Move controls to DS3 controller mappings.
+Mouse: Emulate PSMove with Mouse handler.
+Raw Mouse: Emulate PSMove with Raw Mouse handler.</source>
+        <translation>Поддержка PlayStation Move.
+Fake: Экспериментально! Назначает управление Move на кнопки DS3.
+Mouse: Эмуляция PS Move через обработчик мыши.
+Raw Mouse: Эмуляция PS Move через обработчик Raw Mouse.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="246"/>
+        <source>Buzz! support.
+Select 1 or 2 controllers if the game requires Buzz! controllers and you don&apos;t have real controllers.
+Select Null if the game has support for DualShock or if you have real Buzz! controllers.</source>
+        <translation>Поддержка Buzz!.
+Выберите 1 или 2 контроллера, если игра требует контроллеры Buzz! и у вас их нет.
+Выберите Null, если игра поддерживает DualShock или у вас есть настоящие контроллеры Buzz!.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="247"/>
+        <source>DJ Hero Turntable controller support.
+Select 1 or 2 controllers if the game requires DJ Hero Turntable controllers and you don&apos;t have real turntable controllers.
+Select Null if the game has support for DualShock or if you have real turntable controllers.
+A real turntable controller can be used at the same time as an emulated turntable controller.</source>
+        <translation>Поддержка DJ Hero Turntable.
+Выберите 1 или 2, если игра требует контроллеры DJ Hero и у вас их нет.
+Выберите Null, если игра поддерживает DualShock или у вас есть настоящие контроллеры.
+Настоящий и эмулируемый контроллер можно использовать одновременно.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="248"/>
+        <source>Guitar Hero Live (GHL) Guitar controller support.
+Select 1 or 2 controllers if the game requires GHL Guitar controllers and you don&apos;t have real guitar controllers.
+Select Null if the game has support for DualShock or if you have real guitar controllers.
+A real guitar controller can be used at the same time as an emulated guitar controller.</source>
+        <translation>Поддержка Guitar Hero Live (GHL).
+Выберите 1 или 2, если игра требует контроллеры GHL и у вас их нет.
+Выберите Null, если игра поддерживает DualShock или у вас есть настоящие контроллеры.
+Настоящий и эмулируемый контроллер можно использовать одновременно.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="249"/>
+        <source>Allows pad and keyboard input while the game window is unfocused.</source>
+        <translation>Разрешает ввод с геймпада и клавиатуры, когда окно игры не в фокусе.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="250"/>
+        <source>Shows the raw position of the PS Move input.
+This can be very helpful during calibration screens.</source>
+        <translation>Показывает необработанное положение ввода PS Move.
+Очень полезно на экранах калибровки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="251"/>
+        <source>Select up to 3 emulated MIDI devices and their types.</source>
+        <translation>Выберите до 3 эмулируемых MIDI-устройств и их типы.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="252"/>
+        <source>Loads the SDL GameController database for improved gamepad compatibility. Only used in the SDL pad handler.</source>
+        <translation>Загружает базу данных SDL GameController для улучшения совместимости геймпадов. Используется только обработчиком SDL.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="254"/>
+        <source>Locks the native overlay input to the first player.</source>
+        <translation>Блокирует ввод нативного оверлея на первого игрока.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="258"/>
+        <source>If set to Connected, RPCS3 will allow programs to use your internet connection.</source>
+        <translation>При значении «Подключено» RPCS3 разрешает программам использовать интернет-соединение.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="259"/>
+        <source>If set to RPCN, RPCS3 will use the RPCN server as PSN connection if the game is supported.
+If set to Simulated, RPCS3 will try to fake the PSN connection, but any actual attempt at using the PSN functionality may result in errors or crashes.
+Simulated is only available in custom configurations.</source>
+        <translation>При значении RPCN используется сервер RPCN в качестве PSN, если игра поддерживается.
+При значении «Симулировать» RPCS3 пытается имитировать подключение к PSN, но реальные функции PSN могут вызывать ошибки.
+Режим «Симулировать» доступен только в пользовательских конфигурациях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="260"/>
+        <source>DNS used to resolve hostnames by applications.</source>
+        <translation>DNS для разрешения имён хостов приложениями.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="261"/>
+        <source>DNS Swap List.
+Only available in custom configurations.</source>
+        <translation>Список замены DNS.
+Доступно только в пользовательских конфигурациях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="262"/>
+        <source>Interface IP Address to bind to.
+Only available in custom configurations.</source>
+        <translation>IP-адрес интерфейса для привязки.
+Доступно только в пользовательских конфигурациях.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="263"/>
+        <source>Enable UPNP.
+This will automatically forward ports bound on 0.0.0.0 if your router has UPNP enabled.</source>
+        <translation>Включить UPnP.
+Автоматически пробросит порты, привязанные к 0.0.0.0, если роутер поддерживает UPnP.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="264"/>
+        <source>Changes the RPCN country.</source>
+        <translation>Изменяет страну RPCN.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="265"/>
+        <source>Enable connection to the Clans server.
+Only affects games supporting the Clans feature.</source>
+        <translation>Включает подключение к серверу Clans.
+Влияет только на игры с поддержкой функции Clans.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="269"/>
+        <source>The console region defines the license area of the PS3.
+Depending on the license area, some games may not work.</source>
+        <translation>Регион консоли определяет лицензионную зону PS3.
+В зависимости от зоны некоторые игры могут не работать.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="270"/>
+        <source>Some games may fail to boot if the system language is not available in the game itself.
+Other games will switch language automatically to what is selected here.
+It is recommended leaving this on a language supported by the game.</source>
+        <translation>Некоторые игры могут не запуститься, если системный язык не поддерживается игрой.
+Другие игры автоматически переключатся на выбранный язык.
+Рекомендуется выбирать язык, поддерживаемый игрой.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="271"/>
+        <source>Select the PS3&apos;s date format.</source>
+        <translation>Выберите формат даты PS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="272"/>
+        <source>Select the PS3&apos;s time format.</source>
+        <translation>Выберите формат времени PS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="273"/>
+        <source>Sets the used keyboard layout.
+Currently only US, Japanese and German layouts are fully supported at this moment.</source>
+        <translation>Устанавливает раскладку клавиатуры.
+В данный момент полностью поддерживаются только US, японская и немецкая раскладки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="274"/>
+        <source>The button used for enter/accept/confirm in system dialogs.
+Change this to use the Circle button instead, which is the default configuration on Japanese systems and in many Japanese games.
+In these cases having the cross button assigned can often lead to confusion.</source>
+        <translation>Кнопка для подтверждения/принятия в системных диалогах.
+Измените, чтобы использовать Circle — это конфигурация по умолчанию на японских системах и во многих японских играх.
+В таких случаях назначение X может вызывать путаницу.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="275"/>
+        <source>Required for some Homebrew.
+If unsure, do not use this option.</source>
+        <translation>Требуется для некоторых Homebrew.
+Если не уверены — не используйте.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="276"/>
+        <source>Required for some Homebrew or Game Mods.
+If unsure, do not use this option</source>
+        <translation>Требуется для некоторых Homebrew или модов.
+Если не уверены — не используйте</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="277"/>
+        <source>Automatically removes older files from disk cache on boot if it grows larger than the specified value.
+Games can use the cache folder to temporarily store data outside of system memory. It is not used for long-term storage.
+
+This setting is only available in the global configuration.</source>
+        <translation>Автоматически удаляет старые файлы из дискового кэша при загрузке, если его размер превышает указанное значение.
+Игры могут использовать папку кэша для временного хранения данных вне системной памяти.
+
+Этот параметр доступен только в глобальной конфигурации.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="278"/>
+        <source>Sets the time to be used within the console. This will be applied as an offset that tracks wall clock time.
+Can be reset to current wall clock time by clicking &quot;Set to Now&quot;.</source>
+        <translation>Устанавливает время консоли. Применяется как смещение относительно системного времени.
+Можно сбросить до текущего времени кнопкой «Установить сейчас».</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="283"/>
+        <source>This controller is disabled and will appear as disconnected to software. Choose another handler to enable it.</source>
+        <translation>Этот контроллер отключён и будет виден как отсоединённый. Выберите другой обработчик для включения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="284"/>
+        <source>This port is currently assigned to a custom controller by the application and can&apos;t be changed.</source>
+        <translation>Этот порт назначен приложением для пользовательского контроллера и не может быть изменён.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="285"/>
+        <source>While it is possible to use a keyboard as a pad in RPCS3, the use of an actual controller is strongly recommended.&lt;br&gt;To bind mouse movement to a button or joystick, click on the desired button to activate it, then click and hold while dragging the mouse to a direction.</source>
+        <translation>В RPCS3 можно использовать клавиатуру как геймпад, однако настоятельно рекомендуется использовать реальный контроллер.&lt;br&gt;Чтобы привязать движение мыши к кнопке или стику, нажмите на нужную кнопку для активации, затем нажмите и удерживайте, перемещая мышь в нужную сторону.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="286"/>
+        <source>In order to use the DualShock 3 handler, you need to install the official DualShock 3 driver first.&lt;br&gt;See the &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;RPCS3 Wiki&lt;/a&gt; for instructions.</source>
+        <translation>Для использования обработчика DualShock 3 необходимо сначала установить официальный драйвер DualShock 3.&lt;br&gt;Инструкции см. в &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;вики RPCS3&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="287"/>
+        <source>In order to use the DualShock 3 handler, you might need to add udev rules to let RPCS3 access the controller.&lt;br&gt;See the &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;RPCS3 Wiki&lt;/a&gt; for instructions.</source>
+        <translation>Для использования обработчика DualShock 3 может потребоваться добавить правила udev.&lt;br&gt;Инструкции см. в &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;вики RPCS3&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="288"/>
+        <source>The DualShock 3 handler is recommended for official DualShock 3 controllers.</source>
+        <translation>Обработчик DualShock 3 рекомендуется для официальных контроллеров DualShock 3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="289"/>
+        <source>If you have any issues with the DualShock 4 handler, it might be caused by third-party tools such as DS4Windows. It&apos;s recommended that you disable them while using this handler.</source>
+        <translation>Проблемы с обработчиком DualShock 4 могут быть вызваны сторонними инструментами, например DS4Windows. Рекомендуется отключать их при использовании этого обработчика.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="290"/>
+        <source>In order to use the DualShock 4 handler, you might need to add udev rules to let RPCS3 access the controller.&lt;br&gt;See the &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;RPCS3 Wiki&lt;/a&gt; for instructions.</source>
+        <translation>Для использования обработчика DualShock 4 может потребоваться добавить правила udev.&lt;br&gt;Инструкции см. в &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;вики RPCS3&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="291"/>
+        <source>The DualShock 4 handler is recommended for official DualShock 4 controllers.</source>
+        <translation>Обработчик DualShock 4 рекомендуется для официальных контроллеров DualShock 4.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="292"/>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="293"/>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="294"/>
+        <source>The DualSense handler is recommended for official DualSense controllers.</source>
+        <translation>Обработчик DualSense рекомендуется для официальных контроллеров DualSense.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="295"/>
+        <source>The Skateboard handler is recommended for official RIDE skateboard controllers.</source>
+        <translation>Обработчик Skateboard рекомендуется для официальных скейтбордов RIDE.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="296"/>
+        <source>The PS Move handler is recommended for official PS Move controllers.</source>
+        <translation>Обработчик PS Move рекомендуется для официальных контроллеров PS Move.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="297"/>
+        <source>The XInput handler will work with Xbox controllers and many third-party PC-compatible controllers. Pressure sensitive buttons from SCP are supported when SCP&apos;s XInput1_3.dll is placed in the main RPCS3 directory. For more details, see the &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;RPCS3 Wiki&lt;/a&gt;.</source>
+        <translation>Обработчик XInput работает с контроллерами Xbox и многими сторонними ПК-совместимыми контроллерами. Кнопки с чувствительностью к давлению от SCP поддерживаются при наличии XInput1_3.dll от SCP в папке RPCS3. Подробнее см. в &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;вики RPCS3&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="298"/>
+        <source>The evdev handler should work with any controller that has Linux support.&lt;br&gt;If your joystick is not being centered properly, read the &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;RPCS3 Wiki&lt;/a&gt; for instructions.</source>
+        <translation>Обработчик evdev работает с любым контроллером, поддерживаемым Linux.&lt;br&gt;Если ваш джойстик не центрируется правильно, см. инструкции в &lt;a %0 href=&quot;https://wiki.rpcs3.net/index.php?title=Help:Controller_Configuration&quot;&gt;вики RPCS3&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="299"/>
+        <source>The MMJoystick handler should work with almost any controller recognized by Windows. However, it is recommended that you use the more specific handlers if you have a controller that supports them.</source>
+        <translation>Обработчик MMJoystick работает почти с любым контроллером, распознаваемым Windows. Однако рекомендуется использовать более специфичные обработчики, если ваш контроллер их поддерживает.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="300"/>
+        <source>The SDL handler supports a variety of controllers across different platforms.</source>
+        <translation>Обработчик SDL поддерживает широкий спектр контроллеров на разных платформах.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="302"/>
+        <source>Resets the sensor orientation when pressed.&lt;br&gt;Toggle the checkbox to enable or disable the orientation feature.&lt;br&gt;Currently only used for PS Move interactions.</source>
+        <translation>Сбрасывает ориентацию датчика при нажатии.&lt;br&gt;Установите флажок для включения или отключения функции ориентации.&lt;br&gt;В данный момент используется только для взаимодействий PS Move.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="303"/>
+        <source>Applies the stick multipliers while this special button is pressed.&lt;br&gt;Enable &quot;Toggle&quot; if you want to toggle the analog limiter on button press instead.&lt;br&gt;If no button has been assigned, the stick multipliers are always applied.</source>
+        <translation>Применяет множители стика при удержании этой специальной кнопки.&lt;br&gt;Включите «Переключатель», если хотите переключать ограничитель аналога по нажатию.&lt;br&gt;Если кнопка не назначена, множители применяются всегда.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="304"/>
+        <source>Controls the intensity of pressure sensitive buttons while this special button is pressed.&lt;br&gt;Enable &quot;Toggle&quot; if you want to toggle the intensity on button press instead.&lt;br&gt;Use the percentage to change how hard you want to press a button.</source>
+        <translation>Управляет интенсивностью кнопок с чувствительностью к давлению при удержании специальной кнопки.&lt;br&gt;Включите «Переключатель», чтобы переключать интенсивность по нажатию.&lt;br&gt;Используйте процент для настройки силы нажатия.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="305"/>
+        <source>Controls the deadzone of pressure sensitive buttons. It determines how far the button has to be pressed until it is recognized by the game. The resulting range will be projected onto the full button sensitivity range.</source>
+        <translation>Управляет мёртвой зоной кнопок с чувствительностью к давлению. Определяет, насколько далеко нужно нажать кнопку, чтобы игра её распознала. Результирующий диапазон проецируется на полный диапазон чувствительности.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="306"/>
+        <source>The actual DualShock 3&apos;s stick range is not circular but formed like a rounded square (or squircle) which represents the maximum range of the emulated sticks. You can use the squircle values to modify the stick input if your sticks can&apos;t reach the corners of that range. A value of 0 does not apply any so called squircling. A value of 4000 is usually recommended.</source>
+        <translation>Реальный диапазон стиков DualShock 3 не круглый, а скруглённый квадрат (squircle), представляющий максимальный диапазон эмулируемых стиков. Используйте значения squircle для коррекции ввода, если стики не достигают углов диапазона. Значение 0 — без squircling. Рекомендуется значение 4000.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="307"/>
+        <source>The stick multipliers can be used to change the sensitivity of your stick movements.&lt;br&gt;The default setting is 1 and represents normal input.</source>
+        <translation>Множители стика изменяют чувствительность движений стика.&lt;br&gt;Значение по умолчанию — 1 (нормальный ввод).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="308"/>
+        <source>A stick&apos;s deadzone determines how far the stick has to be moved until it is fully recognized by the game. The resulting range will be projected onto the full input range in order to give you a smooth experience. Movement inside the deadzone is simulated using the anti-deadzone slider (default is 13%), so don&apos;t worry if there is still movement shown in the emulated stick preview.</source>
+        <translation>Мёртвая зона стика определяет, насколько далеко нужно отклонить стик, чтобы игра его полностью распознала. Результирующий диапазон проецируется на полный входной диапазон для плавной работы. Движение внутри мёртвой зоны симулируется через ползунок анти-мёртвой зоны (по умолчанию 13%).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="309"/>
+        <source>The PS3 activates two motors (large and small) to handle controller vibrations.&lt;br&gt;You can enable, disable or even switch these signals for the currently selected pad here.&lt;br&gt;The game sends values from 0-255 to activate the motors.&lt;br&gt;Any value smaller or equal the threshold will be set to 0. This is 63 by default for pad handlers other than DualShock3 in order to emulate the DualShock3&apos;s behavior.</source>
+        <translation>PS3 активирует два мотора (большой и малый) для вибрации контроллера.&lt;br&gt;Здесь можно включить, отключить или поменять местами эти сигналы для выбранного геймпада.&lt;br&gt;Игра отправляет значения 0–255 для активации моторов.&lt;br&gt;Значения не выше порога устанавливаются в 0. По умолчанию это 63 для обработчиков, отличных от DualShock3, для имитации его поведения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="310"/>
+        <source>Use this to configure the gamepad motion controls.</source>
+        <translation>Используется для настройки управления движением геймпада.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="311"/>
+        <source>The emulated stick values (red dots) in the stick preview represent the actual stick positions as they will be visible to the game. The actual DualShock 3&apos;s stick range is not circular but formed like a rounded square (or squircle) which represents the maximum range of the emulated sticks. The blue regular dots represent the raw stick values (including stick multipliers) before they are converted for ingame usage.</source>
+        <translation>Эмулированные значения стиков (красные точки) в предпросмотре отображают фактические позиции стиков, которые видит игра. Реальный диапазон стиков DualShock 3 не круговой, а имеет форму скруглённого квадрата («сквиркла»), представляющего максимальный диапазон эмулированных стиков. Синие точки отображают сырые значения стиков (включая множители) до их преобразования для использования в игре.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="312"/>
+        <source>A trigger&apos;s deadzone determines how far the trigger has to be moved until it is recognized by the game. The resulting range will be projected onto the full input range in order to give you a smooth experience.</source>
+        <translation>Мёртвая зона триггера определяет, насколько далеко нужно нажать триггер, прежде чем игра его распознает. Результирующий диапазон проецируется на полный диапазон ввода для обеспечения плавного управления.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="313"/>
+        <source>With keyboards, you are inevitably restricted to 8 stick directions (4 straight + 4 diagonal). Furthermore, the stick will jump to the maximum value of the chosen direction immediately when a key is pressed. The stick interpolation can be used to work-around both of these issues by smoothening out these directional changes. The lower the value, the longer you have to press or release a key until the maximum amplitude is reached.</source>
+        <translation>При использовании клавиатуры вы ограничены 8 направлениями стика (4 прямых + 4 диагональных). Кроме того, стик мгновенно переходит к максимальному значению при нажатии клавиши. Интерполяция стика позволяет обойти обе проблемы, сглаживая изменения направлений. Чем меньше значение, тем дольше нужно удерживать или отпускать клавишу до достижения максимальной амплитуды.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="314"/>
+        <source>The mouse deadzones represent the games&apos; own deadzones on the x and y axes. Games usually enforce their own deadzones to filter out small unwanted stick movements. In consequence, mouse input feels unintuitive since it relies on immediate responsiveness. You can change these values temporarily during gameplay in order to find out the optimal values for your game (Alt+T and Alt+Y for x, Alt+U and Alt+I for y).</source>
+        <translation>Мёртвые зоны мыши представляют собственные мёртвые зоны игры по осям x и y. Игры применяют их для фильтрации незначительных нежелательных движений стика. Вследствие этого ввод мышью ощущается неинтуитивно. Вы можете временно изменять эти значения во время игры для поиска оптимальных (Alt+T и Alt+Y для x, Alt+U и Alt+I для y).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="315"/>
+        <source>The mouse acceleration can be used to amplify your mouse movements on the x and y axes. Increase these values if your mouse movements feel too slow while playing a game. You can change these values temporarily during gameplay in order to find out the optimal values (Alt+G and Alt+H for x, Alt+J and Alt+K for y). Keep in mind that modern mice usually provide different modes and settings that can be used to change mouse movement speeds as well.</source>
+        <translation>Ускорение мыши усиливает движения мыши по осям x и y. Увеличьте эти значения, если движения мыши кажутся слишком медленными. Вы можете временно изменять их во время игры для поиска оптимальных значений (Alt+G и Alt+H для x, Alt+J и Alt+K для y). Имейте в виду, что современные мыши имеют собственные настройки скорости.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="316"/>
+        <source>The mouse movement mode determines how the mouse movement is translated to pad input.&lt;br&gt;Use the relative mode for traditional mouse movement.&lt;br&gt;Use the absolute mode to use the mouse&apos;s distance to the center of the screen as input value.</source>
+        <translation>Режим движения мыши определяет, как перемещение мыши преобразуется в ввод геймпада.&lt;br&gt;Используйте относительный режим для традиционного управления мышью.&lt;br&gt;Используйте абсолютный режим, чтобы использовать расстояние мыши от центра экрана как значение ввода.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/tooltips.h" line="317"/>
+        <source>Left-click: remap this button.&lt;br&gt;Shift + Left-click: add an additional button mapping.&lt;br&gt;Alt + Left-click: differentiate between trigger press and release (only XInput for now).&lt;br&gt;Right-click: clear this button mapping.</source>
+        <translation>Левая кнопка мыши: переназначить кнопку.&lt;br&gt;Shift + левая кнопка: добавить дополнительное назначение.&lt;br&gt;Alt + левая кнопка: различать нажатие и отпускание триггера (только XInput).&lt;br&gt;Правая кнопка мыши: очистить назначение.</translation>
+    </message>
+</context>
+<context>
+    <name>about_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="14"/>
+        <source>About RPCS3</source>
+        <translation>О RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="107"/>
+        <source>RPCS3 PlayStation 3 Emulator</source>
+        <translation>RPCS3 — эмулятор PlayStation 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="227"/>
+        <source>Developers:</source>
+        <translation>Разработчики:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="262"/>
+        <source>Contributors:</source>
+        <translation>Участники:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="294"/>
+        <source>Supporters:</source>
+        <translation>Спонсоры:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="393"/>
+        <source>GitHub</source>
+        <translation>GitHub</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="400"/>
+        <source>Website</source>
+        <translation>Сайт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="407"/>
+        <source>Forum</source>
+        <translation>Форум</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="414"/>
+        <source>Discord</source>
+        <translation>Discord</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="421"/>
+        <source>Wiki</source>
+        <translation>Wiki</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="428"/>
+        <location filename="rpcs3/rpcs3qt/about_dialog.cpp" line="24"/>
+        <source>Patreon</source>
+        <translation>Patreon</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.ui" line="448"/>
+        <source>Close</source>
+        <translation>Закрыть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.cpp" line="18"/>
+        <source>RPCS3 Version: %1</source>
+        <translation>Версия RPCS3: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/about_dialog.cpp" line="19"/>
+        <source>RPCS3 is an open-source Sony PlayStation 3 emulator and debugger.
+It is written in C++ for Windows, Linux, FreeBSD and MacOS, funded with %0.
+Our developers and contributors are always working hard to ensure this project is the best that it can be.
+There are still plenty of implementations to make and optimizations to do.</source>
+        <translation>RPCS3 — эмулятор и отладчик Sony PlayStation 3 с открытым исходным кодом.
+Написан на C++ для Windows, Linux, FreeBSD и macOS, финансируется за счёт %0.
+Наши разработчики и участники неустанно работают над тем, чтобы проект был как можно лучше.
+Ещё многое предстоит реализовать и оптимизировать.</translation>
+    </message>
+</context>
+<context>
+    <name>auto_pause_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="18"/>
+        <source>To use auto pause: enter the ID(s) of a function or a system call.
+Restart of the game is required to apply. You can enable/disable this in the settings.</source>
+        <translation>Для использования автопаузы: введите ID функции или системного вызова.
+Для применения требуется перезапуск игры. Включить/отключить можно в настройках.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="22"/>
+        <source>Call ID</source>
+        <translation>ID вызова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="22"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="29"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="30"/>
+        <source>Reload</source>
+        <translation>Перезагрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="31"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="32"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="49"/>
+        <source>Auto Pause Manager</source>
+        <translation>Менеджер автопаузы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="132"/>
+        <source>Unset</source>
+        <translation>Не задан</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="137"/>
+        <source>System Call</source>
+        <translation>Системный вызов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="141"/>
+        <source>Function Call</source>
+        <translation>Вызов функции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="156"/>
+        <source>&amp;Add</source>
+        <translation>&amp;Добавить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="157"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/auto_pause_settings_dialog.cpp" line="159"/>
+        <source>&amp;Config</source>
+        <translation>&amp;Настройка</translation>
+    </message>
+</context>
+<context>
+    <name>basic_mouse_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp" line="25"/>
+        <source>Configure Basic Mouse Handler</source>
+        <translation>Настройка базового обработчика мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp" line="48"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp" line="48"/>
+        <source>Reset all settings?</source>
+        <translation>Сбросить все настройки?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp" line="91"/>
+        <location filename="rpcs3/rpcs3qt/basic_mouse_settings_dialog.cpp" line="185"/>
+        <source>[ Waiting %1 ]</source>
+        <translation>[ Ожидание %1 ]</translation>
+    </message>
+</context>
+<context>
+    <name>breakpoint_list</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="24"/>
+        <source>&amp;Delete</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="129"/>
+        <source>Interpreters-Only Feature!</source>
+        <translation>Только для интерпретаторов!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="129"/>
+        <source>Cannot set breakpoints on non-interpreter decoders.</source>
+        <translation>Нельзя устанавливать точки останова на декодеры, не являющиеся интерпретаторами.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="139"/>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="184"/>
+        <source>Invalid Memory For Breakpoints!</source>
+        <translation>Недопустимая память для точек останова!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="139"/>
+        <source>Cannot set breakpoints on non-SPU executable memory!</source>
+        <translation>Нельзя устанавливать точки останова на non-SPU исполняемую память!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="178"/>
+        <source>Unimplemented Breakpoints For Thread Type!</source>
+        <translation>Точки останова не реализованы для данного типа потока!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="178"/>
+        <source>Cannot set breakpoints on a thread not an PPU/SPU currently, sorry.</source>
+        <translation>В данный момент точки останова поддерживаются только для потоков PPU/SPU.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="184"/>
+        <source>Cannot set breakpoints on non-executable memory!</source>
+        <translation>Нельзя устанавливать точки останова на неисполняемую память!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="199"/>
+        <source>Unknown error while setting breakpoint!</source>
+        <translation>Неизвестная ошибка при установке точки останова!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="199"/>
+        <source>Failed to set breakpoints.</source>
+        <translation>Не удалось установить точки останова.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="220"/>
+        <source>&amp;Rename</source>
+        <translation>&amp;Переименовать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="235"/>
+        <source>Add Breakpoint</source>
+        <translation>Добавить точку останова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="244"/>
+        <source>Disable BPM</source>
+        <translation>Отключить BPM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/breakpoint_list.cpp" line="244"/>
+        <source>Enable BPM</source>
+        <translation>Включить BPM</translation>
+    </message>
+</context>
+<context>
+    <name>camera_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="14"/>
+        <source>Camera Settings</source>
+        <translation>Настройки камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="22"/>
+        <source>Handler</source>
+        <translation>Обработчик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="28"/>
+        <source>No handlers found</source>
+        <translation>Обработчики не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="38"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="44"/>
+        <source>No cameras found</source>
+        <translation>Камеры не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="54"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="60"/>
+        <source>No settings found</source>
+        <translation>Настройки не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.ui" line="72"/>
+        <source>Preview</source>
+        <translation>Предпросмотр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="320"/>
+        <source>Camera permissions denied!</source>
+        <translation>Доступ к камерам запрещён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="320"/>
+        <source>RPCS3 has no permissions to access cameras on this device.</source>
+        <translation>RPCS3 не имеет разрешения на доступ к камерам на этом устройстве.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="364"/>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="451"/>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="657"/>
+        <source>Camera not available</source>
+        <translation>Камера недоступна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="364"/>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="451"/>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="657"/>
+        <source>The selected camera is not available.
+It might be blocked by another application.</source>
+        <translation>Выбранная камера недоступна.
+Возможно, она используется другим приложением.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="390"/>
+        <source>%0x%1, %2-%3 FPS, Format=%4</source>
+        <translation>%0x%1, %2-%3 FPS, Формат=%4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/camera_settings_dialog.cpp" line="541"/>
+        <source>%0x%1, %2 FPS, Format=%3</source>
+        <translation>%0x%1, %2 FPS, Формат=%3</translation>
+    </message>
+</context>
+<context>
+    <name>cg_disasm_window</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cg_disasm_window.cpp" line="19"/>
+        <source>Cg Disasm</source>
+        <translation>Cg Disasm</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cg_disasm_window.cpp" line="65"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cg_disasm_window.cpp" line="66"/>
+        <source>Open &amp;Cg binary program</source>
+        <translation>Открыть &amp;Cg бинарную программу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cg_disasm_window.cpp" line="80"/>
+        <source>Select Cg program object</source>
+        <translation>Выбрать объект программы Cg</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cg_disasm_window.cpp" line="80"/>
+        <source>Cg program objects (*.fpo;*.vpo);;</source>
+        <translation>Программы Cg (*.fpo;*.vpo);;</translation>
+    </message>
+</context>
+<context>
+    <name>cheat_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="991"/>
+        <source>Error converting value</source>
+        <translation>Ошибка преобразования значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="991"/>
+        <source>Couldn&apos;t convert the search value you typed to the integer type you selected</source>
+        <translation>Не удалось преобразовать введённое значение к выбранному целочисленному типу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1001"/>
+        <source>Nothing found</source>
+        <translation>Ничего не найдено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1008"/>
+        <source>Too many entries to display (%0)</source>
+        <translation>Слишком много результатов для отображения (%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1069"/>
+        <source>Unsigned 8 bits</source>
+        <translation>Беззнаковое 8 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1070"/>
+        <source>Unsigned 16 bits</source>
+        <translation>Беззнаковое 16 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1071"/>
+        <source>Unsigned 32 bits</source>
+        <translation>Беззнаковое 32 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1072"/>
+        <source>Unsigned 64 bits</source>
+        <translation>Беззнаковое 64 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1073"/>
+        <source>Signed 8 bits</source>
+        <translation>Знаковое 8 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1074"/>
+        <source>Signed 16 bits</source>
+        <translation>Знаковое 16 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1075"/>
+        <source>Signed 32 bits</source>
+        <translation>Знаковое 32 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1076"/>
+        <source>Signed 64 bits</source>
+        <translation>Знаковое 64 бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/cheat_manager.cpp" line="1077"/>
+        <source>Float 32 bits</source>
+        <translation>Float 32 бит</translation>
+    </message>
+</context>
+<context>
+    <name>clans_add_server_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="142"/>
+        <source>Clans: Add Server</source>
+        <translation>Кланы: добавить сервер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="148"/>
+        <source>Description:</source>
+        <translation>Описание:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="150"/>
+        <source>Host:</source>
+        <translation>Адрес:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="169"/>
+        <source>Missing Description!</source>
+        <translation>Описание не указано!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="169"/>
+        <source>You must enter a description!</source>
+        <translation>Необходимо ввести описание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="174"/>
+        <source>Missing Hostname!</source>
+        <translation>Адрес не указан!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="174"/>
+        <source>You must enter a hostname for the server!</source>
+        <translation>Необходимо ввести адрес сервера!</translation>
+    </message>
+</context>
+<context>
+    <name>clans_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="17"/>
+        <source>Clans Configuration</source>
+        <translation>Настройка кланов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="22"/>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="26"/>
+        <source>Server:</source>
+        <translation>Сервер:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="41"/>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="42"/>
+        <source>Del</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="87"/>
+        <source>Existing Server</source>
+        <translation>Сервер уже существует</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="87"/>
+        <source>You already have a server with this description &amp; hostname in the list.</source>
+        <translation>Сервер с таким описанием и адресом уже есть в списке.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="113"/>
+        <source>Cannot Delete</source>
+        <translation>Невозможно удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/clans_settings_dialog.cpp" line="113"/>
+        <source>This server cannot be deleted.</source>
+        <translation>Этот сервер нельзя удалить.</translation>
+    </message>
+</context>
+<context>
+    <name>config_checker</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="27"/>
+        <source>Interesting!</source>
+        <translation>Интересно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="31"/>
+        <source>Found config.
+It seems to match the default config.</source>
+        <translation>Конфигурация найдена.
+Похоже, она соответствует настройкам по умолчанию.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="35"/>
+        <source>Found config.
+Some settings seem to deviate from the default config:</source>
+        <translation>Конфигурация найдена.
+Некоторые настройки отличаются от значений по умолчанию:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="47"/>
+        <source>Ooops!</source>
+        <translation>Упс!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="78"/>
+        <location filename="rpcs3/rpcs3qt/config_checker.cpp" line="88"/>
+        <source>Cannot find any config!</source>
+        <translation>Невозможно найти конфигурацию!</translation>
+    </message>
+</context>
+<context>
+    <name>debugger_add_bp_window</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="20"/>
+        <source>Add a breakpoint</source>
+        <translation>Добавить точку останова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="26"/>
+        <source>Address</source>
+        <translation>Адрес</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="28"/>
+        <source>Address here</source>
+        <translation>Введите адрес</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="41"/>
+        <source>Memory Read</source>
+        <translation>Чтение памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="42"/>
+        <source>Memory Write</source>
+        <translation>Запись в память</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="43"/>
+        <source>Memory Read&amp;Write</source>
+        <translation>Чтение&amp;Запись памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="45"/>
+        <source>Execution</source>
+        <translation>Выполнение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="54"/>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="67"/>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="78"/>
+        <source>Add BP error</source>
+        <translation>Ошибка добавления точки останова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="67"/>
+        <source>Address is empty!</source>
+        <translation>Адрес не указан!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_add_bp_window.cpp" line="78"/>
+        <source>Address is invalid!</source>
+        <translation>Неверный адрес!</translation>
+    </message>
+</context>
+<context>
+    <name>debugger_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="57"/>
+        <source>Debugger [Press F1 for Help]</source>
+        <translation>Отладчик [F1 — справка]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="93"/>
+        <source>Choose a thread</source>
+        <translation>Выберите поток</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="99"/>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1404"/>
+        <source>Go To Address</source>
+        <translation>Перейти к адресу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="100"/>
+        <source>Go To PC</source>
+        <translation>Перейти к PC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="101"/>
+        <source>Step</source>
+        <translation>Шаг</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="102"/>
+        <source>Step Over</source>
+        <translation>Шаг с обходом</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="103"/>
+        <source>Add BP</source>
+        <translation>Добавить точку останова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="272"/>
+        <source>Breakpoint Settings</source>
+        <translation>Настройки точек останова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="275"/>
+        <source>Pause All Threads On Hit</source>
+        <translation>Приостановить все потоки при срабатывании</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="278"/>
+        <source>When set: a breakpoint hit will pause the emulation instead of the current thread.
+Applies on all breakpoints in all threads regardless if set before or after changing this setting.</source>
+        <translation>Если включено: срабатывание точки останова приостановит эмуляцию вместо текущего потока.
+Применяется ко всем точкам останова во всех потоках, независимо от момента изменения этой настройки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="283"/>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1235"/>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1425"/>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="317"/>
+        <source>Debugger Guide &amp; Shortcuts</source>
+        <translation>Руководство отладчика &amp; горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="319"/>
+        <source>Keys Ctrl+G: Go to typed address.
+Keys Ctrl+B: Open breakpoints settings.
+Keys Ctrl+C: Copy instruction contents.
+Keys Ctrl+F: Find thread.
+Keys Alt+S: Capture SPU images of selected SPU or generalized form when used from PPU.
+Keys Alt+S: Launch a memory viewer pointed to the current RSX semaphores location when used from RSX.
+Keys Alt+R: Load last saved SPU state capture.
+Keys Alt+F5: Show the SPU disassmebler dialog.
+Key D: SPU MFC commands logger, MFC debug setting must be enabled.
+Key D: Also PPU calling history logger, interpreter and non-zero call history size must be used.
+Key E: Instruction Editor: click on the instruction you want to modify, then press E.
+Key F: Dedicated floating point mode switch for SPU threads.
+Key R: Registers Editor for selected thread.
+Key N: Show next instruction the thread will execute after marked instruction, does nothing if target is not predictable.
+Key M: Show the Memory Viewer with initial address pointing to the marked instruction.
+Key I: Show RSX method detail.
+Key F10: Perform step-over on instructions. (skip function calls)
+Key F11: Perform single-stepping on instructions.
+Key F1: Show this help dialog.
+Key Up: Scroll one instruction upwards. (address is decremented)
+Key Down: Scroll one instruction downwards. (address is incremented)
+Key Page-Up: Scroll upwards with steps count equal to the viewed instruction count.
+Key Page-Down: Scroll downwards with steps count equal to the viewed instruction count.
+Double-click: Set breakpoints.</source>
+        <translation>Ctrl+G: Перейти к введённому адресу.
+Ctrl+B: Открыть настройки точек останова.
+Ctrl+C: Скопировать содержимое инструкции.
+Ctrl+F: Найти поток.
+Alt+S: Сохранить образы SPU выбранного SPU или в общем виде при использовании из PPU.
+Alt+S: Открыть просмотрщик памяти на текущем местоположении семафоров RSX при использовании из RSX.
+Alt+R: Загрузить последнее сохранённое состояние SPU.
+Alt+F5: Показать диалог дизассемблера SPU.
+D: Логгер команд MFC для SPU, необходимо включить параметр отладки MFC.
+D: Также логгер истории вызовов PPU, необходимо использовать интерпретатор и ненулевой размер истории вызовов.
+E: Редактор инструкций: нажмите на инструкцию для изменения, затем нажмите E.
+F: Переключатель режима операций с плавающей точкой для потоков SPU.
+R: Редактор регистров выбранного потока.
+N: Показать следующую инструкцию потока после отмеченной, ничего не делает если цель непредсказуема.
+M: Открыть просмотрщик памяти с начальным адресом, указывающим на отмеченную инструкцию.
+I: Показать детали метода RSX.
+F10: Выполнить шаг с обходом инструкции. (пропустить вызовы функций)
+F11: Выполнить пошаговое выполнение инструкции.
+F1: Показать этот диалог помощи.
+Стрелка вверх: Прокрутить на одну инструкцию вверх. (адрес уменьшается)
+Стрелка вниз: Прокрутить на одну инструкцию вниз. (адрес увеличивается)
+Page Up: Прокрутить вверх с шагом равным количеству отображаемых инструкций.
+Page Down: Прокрутить вниз с шагом равным количеству отображаемых инструкций.
+Двойной клик: Установить точки останова.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="497"/>
+        <source>Max MFC cmds logged</source>
+        <translation>Макс. записанных команд MFC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="497"/>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="553"/>
+        <source>Decimal only, max allowed is %0.</source>
+        <translation>Только цифры, максимально допустимо %0.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="553"/>
+        <source>Max PPU calls logged</source>
+        <translation>Макс. записанных вызовов PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1217"/>
+        <source>SPU Disassembler Properties</source>
+        <translation>Свойства дизассемблера SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1236"/>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1426"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1238"/>
+        <source>Source Address: </source>
+        <translation>Исходный адрес: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1241"/>
+        <source>Load PC: </source>
+        <translation>Загрузить PC: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1715"/>
+        <source>Show in Memory Viewer</source>
+        <translation>Показать в просмотрщике памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1729"/>
+        <source>No Selection</source>
+        <translation>Ничего не выбрано</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1729"/>
+        <source>Please select a hex value first.</source>
+        <translation>Сначала выберите шестнадцатеричное значение.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1738"/>
+        <source>Invalid Hex</source>
+        <translation>Неверное hex-значение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.cpp" line="1738"/>
+        <source>”%0” is not a valid 32-bit hex value.</source>
+        <translation>«%0» не является допустимым 32-битным hex-значением.</translation>
+    </message>
+</context>
+<context>
+    <name>debugger_list</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_list.cpp" line="27"/>
+        <source>ASM</source>
+        <translation>ASM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_list.cpp" line="409"/>
+        <source>RSX Command Detail</source>
+        <translation>Детали команды RSX</translation>
+    </message>
+</context>
+<context>
+    <name>dimensions_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="573"/>
+        <source>Dimensions Manager</source>
+        <translation>Менеджер Dimensions</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="583"/>
+        <source>Active Dimensions Figures:</source>
+        <translation>Активные фигурки Dimensions:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="627"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="628"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="629"/>
+        <source>Load</source>
+        <translation>Загрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="630"/>
+        <source>Move</source>
+        <translation>Переместить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="643"/>
+        <source>Unknown Figure</source>
+        <translation>Неизвестная фигурка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="648"/>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="691"/>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="732"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="708"/>
+        <source>Select Dimensions File</source>
+        <translation>Выбрать файл Dimensions</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="708"/>
+        <source>Dimensions Figure (*.bin);;</source>
+        <translation>Фигурка Dimensions (*.bin);;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="746"/>
+        <source>Failed to open the figure file!</source>
+        <translation>Не удалось открыть файл фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="746"/>
+        <source>Failed to open the figure file(%1)!
+File may already be in use on the base.</source>
+        <translation>Не удалось открыть файл фигурки (%1)!
+Файл уже может использоваться базой.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="753"/>
+        <source>Failed to read the figure file!</source>
+        <translation>Не удалось прочитать файл фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="753"/>
+        <source>Failed to read the figure file(%1)!
+File was too small.</source>
+        <translation>Не удалось прочитать файл фигурки (%1)!
+Файл слишком мал.</translation>
+    </message>
+</context>
+<context>
+    <name>downloader</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/downloader.cpp" line="62"/>
+        <source>Please wait... Trying again</source>
+        <translation>Подождите... Повторная попытка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/downloader.cpp" line="149"/>
+        <source>Please wait...</source>
+        <translation>Подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/downloader.cpp" line="149"/>
+        <source>Abort</source>
+        <translation>Прервать</translation>
+    </message>
+</context>
+<context>
+    <name>elf_memory_dumping_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="23"/>
+        <source>SPU ELF Dumper</source>
+        <translation>Дамп SPU ELF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="33"/>
+        <source>PPU Address: 0x00000000, LS Address: 0x00000, Segment Size: 0x00000, Flags: 0x0</source>
+        <translation>PPU-адрес: 0x00000000, LS-адрес: 0x00000, Размер сегмента: 0x00000, Флаги: 0x0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="54"/>
+        <source>Add new segment</source>
+        <translation>Добавить сегмент</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="59"/>
+        <source>Remove segment</source>
+        <translation>Удалить сегмент</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="64"/>
+        <source>Save To ELF</source>
+        <translation>Сохранить в ELF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="65"/>
+        <source>Save To An ELF file</source>
+        <translation>Сохранить в ELF-файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="69"/>
+        <source>Segment Size:</source>
+        <translation>Размер сегмента:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="73"/>
+        <source>PPU Address:</source>
+        <translation>PPU-адрес:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="76"/>
+        <source>LS Address:</source>
+        <translation>LS-адрес:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="79"/>
+        <source>Flags:</source>
+        <translation>Флаги:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="128"/>
+        <source>Segment Size</source>
+        <translation>Размер сегмента</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="129"/>
+        <source>PPU Address</source>
+        <translation>PPU-адрес</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="130"/>
+        <source>LS Address</source>
+        <translation>LS-адрес</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="131"/>
+        <source>Segment Flags</source>
+        <translation>Флаги сегмента</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="135"/>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="141"/>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="147"/>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="153"/>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="167"/>
+        <source>Failed To Add Segment</source>
+        <translation>Не удалось добавить сегмент</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="135"/>
+        <source>Segment parameters are incorrect:
+%1</source>
+        <translation>Параметры сегмента некорректны:
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="141"/>
+        <source>SPU segment size must be 4 bytes aligned.</source>
+        <translation>Размер SPU-сегмента должен быть выровнен по 4 байта.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="147"/>
+        <source>SPU segment range is invalid.</source>
+        <translation>Диапазон SPU-сегмента недействителен.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="153"/>
+        <source>PPU address range is not accessible.</source>
+        <translation>Диапазон PPU-адресов недоступен.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="167"/>
+        <source>SPU segment overlaps with previous SPU segment(s)
+</source>
+        <translation>SPU-сегмент перекрывается с предыдущим(-и) SPU-сегментом(-ами)
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="172"/>
+        <source>PPU Address: 0x%0, LS Address: 0x%1, Segment Size: 0x%2, Flags: 0x%3</source>
+        <translation>PPU-адрес: 0x%0, LS-адрес: 0x%1, Размер сегмента: 0x%2, Флаги: 0x%3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="206"/>
+        <source>Capture</source>
+        <translation>Захватить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="220"/>
+        <source>Save Failure</source>
+        <translation>Ошибка сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/elf_memory_dumping_dialog.cpp" line="220"/>
+        <source>Failed to save SPU ELF.</source>
+        <translation>Не удалось сохранить SPU ELF.</translation>
+    </message>
+</context>
+<context>
+    <name>emu_settings</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="138"/>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="158"/>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="191"/>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="198"/>
+        <source>Config Error</source>
+        <translation>Ошибка конфигурации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="138"/>
+        <source>Failed to load default config:
+%0</source>
+        <translation>Не удалось загрузить конфигурацию по умолчанию:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="158"/>
+        <source>Failed to load global config:
+File: %0
+Error: %1</source>
+        <translation>Не удалось загрузить глобальную конфигурацию:
+Файл: %0
+Ошибка: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="191"/>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="198"/>
+        <source>Failed to load custom config:
+File: %0
+Error: %1</source>
+        <translation>Не удалось загрузить пользовательскую конфигурацию:
+Файл: %0
+Ошибка: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1002"/>
+        <source>Fix invalid settings?</source>
+        <translation>Исправить недействительные настройки?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1003"/>
+        <source>Your config file contained one or more unrecognized values for settings.
+Their default value will be used until they are corrected.
+Consider that a correction might render them invalid for other versions of RPCS3.
+
+Do you wish to let the program correct them for you?
+This change will only be final when you save the config.</source>
+        <translation>Файл конфигурации содержит одно или несколько нераспознанных значений настроек.
+Их значения по умолчанию будут использоваться до исправления.
+Учтите, что исправление может сделать их недействительными для других версий RPCS3.
+
+Разрешить программе исправить их автоматически?
+Изменение будет окончательным только после сохранения конфигурации.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1033"/>
+        <source>Safe</source>
+        <comment>SPU block size</comment>
+        <translation>Безопасный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1034"/>
+        <source>Mega</source>
+        <comment>SPU block size</comment>
+        <translation>Мега</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1035"/>
+        <source>Giga</source>
+        <comment>SPU block size</comment>
+        <translation>Гига</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1041"/>
+        <source>RPCS3 Scheduler</source>
+        <comment>Thread Scheduler Mode</comment>
+        <translation>Планировщик RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1042"/>
+        <source>RPCS3 Alternative Scheduler</source>
+        <comment>Thread Scheduler Mode</comment>
+        <translation>Альтернативный планировщик RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1043"/>
+        <source>Operating System</source>
+        <comment>Thread Scheduler Mode</comment>
+        <translation>Операционная система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1049"/>
+        <source>Disable Video Output</source>
+        <comment>Video renderer</comment>
+        <translation>Отключить видеовыход</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1050"/>
+        <source>OpenGL</source>
+        <comment>Video renderer</comment>
+        <translation>OpenGL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1051"/>
+        <source>Vulkan</source>
+        <comment>Video renderer</comment>
+        <translation>Vulkan</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1057"/>
+        <source>Legacy (single threaded)</source>
+        <comment>Shader Mode</comment>
+        <translation>Устаревший (однопоточный)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1058"/>
+        <source>Async (multi threaded)</source>
+        <comment>Shader Mode</comment>
+        <translation>Асинхронный (многопоточный)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1059"/>
+        <source>Async with Shader Interpreter</source>
+        <comment>Shader Mode</comment>
+        <translation>Асинхронный с интерпретатором шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1060"/>
+        <source>Shader Interpreter only</source>
+        <comment>Shader Mode</comment>
+        <translation>Только интерпретатор шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1066"/>
+        <source>1080p</source>
+        <comment>Resolution</comment>
+        <translation>1080p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1067"/>
+        <source>1080i</source>
+        <comment>Resolution</comment>
+        <translation>1080i</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1068"/>
+        <source>720p</source>
+        <comment>Resolution</comment>
+        <translation>720p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1069"/>
+        <source>480p</source>
+        <comment>Resolution</comment>
+        <translation>480p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1070"/>
+        <source>480i</source>
+        <comment>Resolution</comment>
+        <translation>480i</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1071"/>
+        <source>576p</source>
+        <comment>Resolution</comment>
+        <translation>576p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1072"/>
+        <source>576i</source>
+        <comment>Resolution</comment>
+        <translation>576i</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1073"/>
+        <source>1600x1080p</source>
+        <comment>Resolution</comment>
+        <translation>1600x1080p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1074"/>
+        <source>1440x1080p</source>
+        <comment>Resolution</comment>
+        <translation>1440x1080p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1075"/>
+        <source>1280x1080p</source>
+        <comment>Resolution</comment>
+        <translation>1280x1080p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1076"/>
+        <source>960x1080p</source>
+        <comment>Resolution</comment>
+        <translation>960x1080p</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1082"/>
+        <source>Off</source>
+        <comment>Frame limit</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1083"/>
+        <source>30</source>
+        <comment>Frame limit</comment>
+        <translation>30</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1084"/>
+        <source>50</source>
+        <comment>Frame limit</comment>
+        <translation>50</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1085"/>
+        <source>60</source>
+        <comment>Frame limit</comment>
+        <translation>60</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1086"/>
+        <source>120</source>
+        <comment>Frame limit</comment>
+        <translation>120</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1087"/>
+        <source>Display</source>
+        <comment>Frame limit</comment>
+        <translation>Экран</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1088"/>
+        <source>Auto</source>
+        <comment>Frame limit</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1089"/>
+        <source>PS3 Native</source>
+        <comment>Frame limit</comment>
+        <translation>PS3 Нативный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1090"/>
+        <source>Infinite</source>
+        <comment>Frame limit</comment>
+        <translation>Бесконечно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1096"/>
+        <source>Disabled</source>
+        <comment>MSAA</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1097"/>
+        <source>Auto</source>
+        <comment>MSAA</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1103"/>
+        <source>Auto</source>
+        <comment>Shader Precision</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1104"/>
+        <source>Ultra</source>
+        <comment>Shader Precision</comment>
+        <translation>Ультра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1105"/>
+        <source>High</source>
+        <comment>Shader Precision</comment>
+        <translation>Высокое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1106"/>
+        <source>Low</source>
+        <comment>Shader Precision</comment>
+        <translation>Низкое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1112"/>
+        <source>Nearest</source>
+        <comment>Output Scaling Mode</comment>
+        <translation>Ближайший</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1113"/>
+        <source>Bilinear</source>
+        <comment>Output Scaling Mode</comment>
+        <translation>Билинейный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1114"/>
+        <source>FidelityFX Super Resolution 1</source>
+        <comment>Output Scaling Mode</comment>
+        <translation>FidelityFX Super Resolution 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1120"/>
+        <source>Disable Audio Output</source>
+        <comment>Audio renderer</comment>
+        <translation>Отключить аудиовыход</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1122"/>
+        <source>XAudio2</source>
+        <comment>Audio renderer</comment>
+        <translation>XAudio2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1124"/>
+        <source>Cubeb</source>
+        <comment>Audio renderer</comment>
+        <translation>Cubeb</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1126"/>
+        <source>FAudio</source>
+        <comment>Audio renderer</comment>
+        <translation>FAudio</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1133"/>
+        <source>Disabled</source>
+        <comment>Microphone handler</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1134"/>
+        <source>Standard</source>
+        <comment>Microphone handler</comment>
+        <translation>Стандартный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1135"/>
+        <source>SingStar</source>
+        <comment>Microphone handler</comment>
+        <translation>SingStar</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1136"/>
+        <source>Real SingStar</source>
+        <comment>Microphone handler</comment>
+        <translation>Real SingStar</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1137"/>
+        <source>Rocksmith</source>
+        <comment>Microphone handler</comment>
+        <translation>Rocksmith</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1143"/>
+        <source>Null</source>
+        <comment>Keyboard handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1144"/>
+        <source>Basic</source>
+        <comment>Keyboard handler</comment>
+        <translation>Базовый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1150"/>
+        <source>Null</source>
+        <comment>Mouse handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1151"/>
+        <source>Basic</source>
+        <comment>Mouse handler</comment>
+        <translation>Базовый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1152"/>
+        <source>Raw</source>
+        <comment>Mouse handler</comment>
+        <translation>Сырой ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1158"/>
+        <source>Unknown</source>
+        <comment>Camera type</comment>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1159"/>
+        <source>EyeToy</source>
+        <comment>Camera type</comment>
+        <translation>EyeToy</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1160"/>
+        <source>PS Eye</source>
+        <comment>Camera type</comment>
+        <translation>PS Eye</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1161"/>
+        <source>UVC 1.1</source>
+        <comment>Camera type</comment>
+        <translation>UVC 1.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1167"/>
+        <source>No</source>
+        <comment>Camera flip</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1168"/>
+        <source>Flip horizontally</source>
+        <comment>Camera flip</comment>
+        <translation>Отразить по горизонтали</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1169"/>
+        <source>Flip vertically</source>
+        <comment>Camera flip</comment>
+        <translation>Отразить по вертикали</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1170"/>
+        <source>Flip both axes</source>
+        <comment>Camera flip</comment>
+        <translation>Отразить по обеим осям</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1176"/>
+        <source>Null</source>
+        <comment>Camera handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1177"/>
+        <source>Fake</source>
+        <comment>Camera handler</comment>
+        <translation>Эмулируемый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1178"/>
+        <source>Qt</source>
+        <comment>Camera handler</comment>
+        <translation>Qt</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1180"/>
+        <source>SDL</source>
+        <comment>Camera handler</comment>
+        <translation>SDL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1187"/>
+        <source>Null</source>
+        <comment>Music handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1188"/>
+        <source>Qt</source>
+        <comment>Music handler</comment>
+        <translation>Qt</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1194"/>
+        <source>Single-threaded</source>
+        <comment>Pad handler mode</comment>
+        <translation>Однопоточный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1195"/>
+        <source>Multi-threaded</source>
+        <comment>Pad handler mode</comment>
+        <translation>Многопоточный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1201"/>
+        <source>Null</source>
+        <comment>Move handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1202"/>
+        <source>Real</source>
+        <comment>Move handler</comment>
+        <translation>Реальный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1203"/>
+        <source>Fake</source>
+        <comment>Move handler</comment>
+        <translation>Эмулируемый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1204"/>
+        <source>Mouse</source>
+        <comment>Move handler</comment>
+        <translation>Мышь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1205"/>
+        <source>Raw Mouse</source>
+        <comment>Move handler</comment>
+        <translation>Мышь (сырой ввод)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1207"/>
+        <source>Gun</source>
+        <comment>Gun handler</comment>
+        <translation>Пистолет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1214"/>
+        <source>Null (use real Buzzers)</source>
+        <comment>Buzz handler</comment>
+        <translation>Нет (использовать реальные Buzzer)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1215"/>
+        <source>1 controller (1-4 players)</source>
+        <comment>Buzz handler</comment>
+        <translation>1 контроллер (1–4 игрока)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1216"/>
+        <source>2 controllers (5-7 players)</source>
+        <comment>Buzz handler</comment>
+        <translation>2 контроллера (5–7 игроков)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1222"/>
+        <source>Null</source>
+        <comment>Turntable handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1223"/>
+        <source>1 controller</source>
+        <comment>Turntable handler</comment>
+        <translation>1 контроллер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1224"/>
+        <source>2 controllers</source>
+        <comment>Turntable handler</comment>
+        <translation>2 контроллера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1230"/>
+        <source>Null</source>
+        <comment>GHLtar handler</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1231"/>
+        <source>1 controller</source>
+        <comment>GHLtar handler</comment>
+        <translation>1 контроллер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1232"/>
+        <source>2 controllers</source>
+        <comment>GHLtar handler</comment>
+        <translation>2 контроллера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1238"/>
+        <source>Disconnected</source>
+        <comment>Internet Status</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1239"/>
+        <source>Connected</source>
+        <comment>Internet Status</comment>
+        <translation>Подключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1245"/>
+        <source>Disconnected</source>
+        <comment>PSN Status</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1246"/>
+        <source>Simulated</source>
+        <comment>PSN Status</comment>
+        <translation>Симулируется</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1247"/>
+        <source>RPCN</source>
+        <comment>PSN Status</comment>
+        <translation>RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1253"/>
+        <source>As Host</source>
+        <comment>Sleep timers accuracy</comment>
+        <translation>Как у хоста</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1254"/>
+        <source>Usleep Only</source>
+        <comment>Sleep timers accuracy</comment>
+        <translation>Только Usleep</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1255"/>
+        <source>All Timers</source>
+        <comment>Sleep timers accuracy</comment>
+        <translation>Все таймеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1261"/>
+        <source>Fast</source>
+        <comment>RSX FIFO Fetch Accuracy</comment>
+        <translation>Быстро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1262"/>
+        <source>Atomic</source>
+        <comment>RSX FIFO Fetch Accuracy</comment>
+        <translation>Атомарно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1263"/>
+        <source>Ordered &amp; Atomic</source>
+        <comment>RSX FIFO Fetch Accuracy</comment>
+        <translation>Упорядоченно и атомарно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1264"/>
+        <source>PS3</source>
+        <comment>RSX FIFO Fetch Accuracy</comment>
+        <translation>PS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1270"/>
+        <source>None</source>
+        <comment>Detail Level</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1271"/>
+        <source>Minimal</source>
+        <comment>Detail Level</comment>
+        <translation>Минимальный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1272"/>
+        <source>Low</source>
+        <comment>Detail Level</comment>
+        <translation>Низкий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1273"/>
+        <source>Medium</source>
+        <comment>Detail Level</comment>
+        <translation>Средний</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1274"/>
+        <source>High</source>
+        <comment>Detail Level</comment>
+        <translation>Высокий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1281"/>
+        <source>Minimal</source>
+        <comment>Perf Graph Detail Level</comment>
+        <translation>Минимальный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1282"/>
+        <source>Show Min And Max</source>
+        <comment>Perf Graph Detail Level</comment>
+        <translation>Показать мин и макс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1283"/>
+        <source>Show 1% Low And Average</source>
+        <comment>Perf Graph Detail Level</comment>
+        <translation>Показать 1% минимум и среднее</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1284"/>
+        <source>Show All</source>
+        <comment>Perf Graph Detail Level</comment>
+        <translation>Показать всё</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1290"/>
+        <source>Top Left</source>
+        <comment>Performance overlay position</comment>
+        <translation>Верхний левый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1291"/>
+        <source>Top Right</source>
+        <comment>Performance overlay position</comment>
+        <translation>Верхний правый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1292"/>
+        <source>Bottom Left</source>
+        <comment>Performance overlay position</comment>
+        <translation>Нижний левый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1293"/>
+        <source>Bottom Right</source>
+        <comment>Performance overlay position</comment>
+        <translation>Нижний правый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1299"/>
+        <source>Interpreter (static)</source>
+        <comment>PPU decoder</comment>
+        <translation>Интерпретатор (статический)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1300"/>
+        <source>Recompiler (LLVM)</source>
+        <comment>PPU decoder</comment>
+        <translation>Рекомпилятор (LLVM)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1306"/>
+        <source>Interpreter (static)</source>
+        <comment>SPU decoder</comment>
+        <translation>Интерпретатор (статический)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1307"/>
+        <source>Interpreter (dynamic)</source>
+        <comment>SPU decoder</comment>
+        <translation>Интерпретатор (динамический)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1308"/>
+        <source>Recompiler (ASMJIT)</source>
+        <comment>SPU decoder</comment>
+        <translation>Рекомпилятор (ASMJIT)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1309"/>
+        <source>Recompiler (LLVM)</source>
+        <comment>SPU decoder</comment>
+        <translation>Рекомпилятор (LLVM)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1315"/>
+        <source>Enter with circle</source>
+        <comment>Enter button assignment</comment>
+        <translation>Подтверждение кнопкой Circle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1316"/>
+        <source>Enter with cross</source>
+        <comment>Enter button assignment</comment>
+        <translation>Подтверждение кнопкой Cross</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1322"/>
+        <source>Stereo</source>
+        <comment>Audio format</comment>
+        <translation>Стерео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1323"/>
+        <source>Surround 5.1</source>
+        <comment>Audio format</comment>
+        <translation>Объёмный 5.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1324"/>
+        <source>Surround 7.1</source>
+        <comment>Audio format</comment>
+        <translation>Объёмный 7.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1325"/>
+        <source>Manual</source>
+        <comment>Audio format</comment>
+        <translation>Вручную</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1326"/>
+        <source>Automatic</source>
+        <comment>Audio format</comment>
+        <translation>Автоматически</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1332"/>
+        <source>Linear PCM 2 Ch. 48 kHz</source>
+        <comment>Audio format flag</comment>
+        <translation>Linear PCM 2 Ch. 48 kHz</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1333"/>
+        <source>Linear PCM 5.1 Ch. 48 kHz</source>
+        <comment>Audio format flag</comment>
+        <translation>Linear PCM 5.1 Ch. 48 kHz</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1334"/>
+        <source>Linear PCM 7.1 Ch. 48 kHz</source>
+        <comment>Audio format flag</comment>
+        <translation>Linear PCM 7.1 Ch. 48 kHz</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1335"/>
+        <source>Dolby Digital 5.1 Ch.</source>
+        <comment>Audio format flag</comment>
+        <translation>Dolby Digital 5.1 Ch.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1336"/>
+        <source>DTS 5.1 Ch.</source>
+        <comment>Audio format flag</comment>
+        <translation>DTS 5.1 Ch.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1342"/>
+        <source>None</source>
+        <comment>Audio Provider</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1343"/>
+        <source>CellAudio</source>
+        <comment>Audio Provider</comment>
+        <translation>CellAudio</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1344"/>
+        <source>RSXAudio</source>
+        <comment>Audio Provider</comment>
+        <translation>RSXAudio</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1350"/>
+        <source>HDMI 0</source>
+        <comment>Audio Avport</comment>
+        <translation>HDMI 0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1351"/>
+        <source>HDMI 1</source>
+        <comment>Audio Avport</comment>
+        <translation>HDMI 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1352"/>
+        <source>AV multiout</source>
+        <comment>Audio Avport</comment>
+        <translation>AV multiout</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1353"/>
+        <source>SPDIF 0</source>
+        <comment>Audio Avport</comment>
+        <translation>SPDIF 0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1354"/>
+        <source>SPDIF 1</source>
+        <comment>Audio Avport</comment>
+        <translation>SPDIF 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1360"/>
+        <source>Auto</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1361"/>
+        <source>Mono</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Моно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1362"/>
+        <source>Stereo</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Стерео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1363"/>
+        <source>Stereo LFE</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Стерео LFE</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1364"/>
+        <source>Quadraphonic</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Квадрофония</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1365"/>
+        <source>Quadraphonic LFE</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Квадрофония LFE</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1366"/>
+        <source>Surround 5.1</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Объёмный 5.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1367"/>
+        <source>Surround 7.1</source>
+        <comment>Audio Channel Layout</comment>
+        <translation>Объёмный 7.1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1373"/>
+        <source>Japan</source>
+        <comment>License Area</comment>
+        <translation>Япония</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1374"/>
+        <source>America</source>
+        <comment>License Area</comment>
+        <translation>Америка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1375"/>
+        <source>Europe, Oceania, Middle East, Russia</source>
+        <comment>License Area</comment>
+        <translation>Европа, Океания, Ближний Восток, Россия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1376"/>
+        <source>Southeast Asia</source>
+        <comment>License Area</comment>
+        <translation>Юго-Восточная Азия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1377"/>
+        <source>Korea</source>
+        <comment>License Area</comment>
+        <translation>Корея</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1378"/>
+        <source>China</source>
+        <comment>License Area</comment>
+        <translation>Китай</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1379"/>
+        <source>Other</source>
+        <comment>License Area</comment>
+        <translation>Другое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1385"/>
+        <source>Safe</source>
+        <comment>Asynchronous Queue Scheduler</comment>
+        <translation>Безопасный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1386"/>
+        <source>Fast</source>
+        <comment>Asynchronous Queue Scheduler</comment>
+        <translation>Быстрый</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1392"/>
+        <source>Year/Month/Day</source>
+        <comment>Date Format</comment>
+        <translation>Год/Месяц/День</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1393"/>
+        <source>Day/Month/Year</source>
+        <comment>Date Format</comment>
+        <translation>День/Месяц/Год</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1394"/>
+        <source>Month/Day/Year</source>
+        <comment>Date Format</comment>
+        <translation>Месяц/День/Год</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1400"/>
+        <source>12-hour clock</source>
+        <comment>Time Format</comment>
+        <translation>12-часовой формат</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1401"/>
+        <source>24-hour clock</source>
+        <comment>Time Format</comment>
+        <translation>24-часовой формат</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1407"/>
+        <source>Japanese</source>
+        <comment>System Language</comment>
+        <translation>Японский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1408"/>
+        <source>English (US)</source>
+        <comment>System Language</comment>
+        <translation>Английский (США)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1409"/>
+        <source>French</source>
+        <comment>System Language</comment>
+        <translation>Французский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1410"/>
+        <source>Spanish</source>
+        <comment>System Language</comment>
+        <translation>Испанский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1411"/>
+        <source>German</source>
+        <comment>System Language</comment>
+        <translation>Немецкий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1412"/>
+        <source>Italian</source>
+        <comment>System Language</comment>
+        <translation>Итальянский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1413"/>
+        <source>Dutch</source>
+        <comment>System Language</comment>
+        <translation>Нидерландский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1414"/>
+        <source>Portuguese (Portugal)</source>
+        <comment>System Language</comment>
+        <translation>Португальский (Португалия)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1415"/>
+        <source>Russian</source>
+        <comment>System Language</comment>
+        <translation>Русский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1416"/>
+        <source>Korean</source>
+        <comment>System Language</comment>
+        <translation>Корейский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1417"/>
+        <source>Chinese (Traditional)</source>
+        <comment>System Language</comment>
+        <translation>Китайский (традиционный)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1418"/>
+        <source>Chinese (Simplified)</source>
+        <comment>System Language</comment>
+        <translation>Китайский (упрощённый)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1419"/>
+        <source>Finnish</source>
+        <comment>System Language</comment>
+        <translation>Финский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1420"/>
+        <source>Swedish</source>
+        <comment>System Language</comment>
+        <translation>Шведский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1421"/>
+        <source>Danish</source>
+        <comment>System Language</comment>
+        <translation>Датский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1422"/>
+        <source>Norwegian</source>
+        <comment>System Language</comment>
+        <translation>Норвежский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1423"/>
+        <source>Polish</source>
+        <comment>System Language</comment>
+        <translation>Польский</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1424"/>
+        <source>English (UK)</source>
+        <comment>System Language</comment>
+        <translation>Английский (Великобритания)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1425"/>
+        <source>Portuguese (Brazil)</source>
+        <comment>System Language</comment>
+        <translation>Португальский (Бразилия)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1426"/>
+        <source>Turkish</source>
+        <comment>System Language</comment>
+        <translation>Турецкий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1434"/>
+        <source>English keyboard (US standard)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Английская клавиатура (стандарт США)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1435"/>
+        <source>Japanese keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Японская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1436"/>
+        <source>Japanese keyboard (Kana state)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Японская клавиатура (режим каны)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1437"/>
+        <source>German keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Немецкая клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1438"/>
+        <source>Spanish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Испанская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1439"/>
+        <source>French keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Французская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1440"/>
+        <source>Italian keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Итальянская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1441"/>
+        <source>Dutch keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Нидерландская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1442"/>
+        <source>Portuguese keyboard (Portugal)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Португальская клавиатура (Португалия)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1443"/>
+        <source>Russian keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Русская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1444"/>
+        <source>English keyboard (UK standard)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Английская клавиатура (стандарт Великобритании)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1445"/>
+        <source>Korean keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Корейская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1446"/>
+        <source>Norwegian keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Норвежская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1447"/>
+        <source>Finnish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Финская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1448"/>
+        <source>Danish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Датская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1449"/>
+        <source>Swedish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Шведская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1450"/>
+        <source>Chinese keyboard (Traditional)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Китайская клавиатура (традиционная)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1451"/>
+        <source>Chinese keyboard (Simplified)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Китайская клавиатура (упрощённая)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1452"/>
+        <source>French keyboard (Switzerland)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Французская клавиатура (Швейцария)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1453"/>
+        <source>German keyboard (Switzerland)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Немецкая клавиатура (Швейцария)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1454"/>
+        <source>French keyboard (Canada)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Французская клавиатура (Канада)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1455"/>
+        <source>French keyboard (Belgium)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Французская клавиатура (Бельгия)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1456"/>
+        <source>Polish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Польская клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1457"/>
+        <source>Portuguese keyboard (Brazil)</source>
+        <comment>Keyboard Type</comment>
+        <translation>Португальская клавиатура (Бразилия)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1458"/>
+        <source>Turkish keyboard</source>
+        <comment>Keyboard Type</comment>
+        <translation>Турецкая клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1464"/>
+        <source>Automatic (Default)</source>
+        <comment>Exclusive Fullscreen Mode</comment>
+        <translation>Автоматически (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1465"/>
+        <source>Prefer borderless fullscreen</source>
+        <comment>Exclusive Fullscreen Mode</comment>
+        <translation>Предпочитать полноэкранный без рамок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1466"/>
+        <source>Prefer exclusive fullscreen</source>
+        <comment>Exclusive Fullscreen Mode</comment>
+        <translation>Предпочитать эксклюзивный полноэкранный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1472"/>
+        <source>Disabled</source>
+        <comment>3D Display Mode</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1473"/>
+        <source>Side-by-side</source>
+        <comment>3D Display Mode</comment>
+        <translation>Бок о бок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1474"/>
+        <source>Over-under</source>
+        <comment>3D Display Mode</comment>
+        <translation>Верх-вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1475"/>
+        <source>Interlaced</source>
+        <comment>3D Display Mode</comment>
+        <translation>С чересстрочной развёрткой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1476"/>
+        <source>Anaglyph Red-Green</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф красный-зелёный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1477"/>
+        <source>Anaglyph Red-Blue</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф красный-синий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1478"/>
+        <source>Anaglyph Red-Cyan</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф красный-голубой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1479"/>
+        <source>Anaglyph Magenta-Cyan</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф пурпурный-голубой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1480"/>
+        <source>Anaglyph Green-Magenta (Trioscopic)</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф зелёный-пурпурный (Trioscopic)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1481"/>
+        <source>Anaglyph Amber-Blue (ColorCode 3D)</source>
+        <comment>3D Display Mode</comment>
+        <translation>Анаглиф янтарный-синий (ColorCode 3D)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1487"/>
+        <source>Guitar (17 frets)</source>
+        <comment>Midi Device Type</comment>
+        <translation>Гитара (17 ладов)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1488"/>
+        <source>Guitar (22 frets)</source>
+        <comment>Midi Device Type</comment>
+        <translation>Гитара (22 лада)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1489"/>
+        <source>Keyboard</source>
+        <comment>Midi Device Type</comment>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1490"/>
+        <source>Drums</source>
+        <comment>Midi Device Type</comment>
+        <translation>Барабаны</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1496"/>
+        <source>Accurate XFloat</source>
+        <translation>Точный XFloat</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1497"/>
+        <source>Approximate XFloat</source>
+        <translation>Приблизительный XFloat</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1498"/>
+        <source>Relaxed XFloat</source>
+        <translation>Расслабленный XFloat</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emu_settings.cpp" line="1499"/>
+        <source>Inaccurate XFloat</source>
+        <translation>Неточный XFloat</translation>
+    </message>
+</context>
+<context>
+    <name>emulated_logitech_g27_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="607"/>
+        <source>Configure Emulated Logitech G27 Wheel</source>
+        <translation>Настройка эмулируемого руля Logitech G27</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="635"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="635"/>
+        <source>Reset all?</source>
+        <translation>Сбросить всё?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="646"/>
+        <source>Warning: Force feedback output were meant for Logitech G27, on stronger wheels please adjust force strength accordingly in your wheel software.</source>
+        <translation>Внимание: сигналы силовой обратной связи рассчитаны на Logitech G27. Для более мощных рулей отрегулируйте силу в ПО руля.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="651"/>
+        <source>Note: Please DO NOT map your wheel onto gamepads, only map it here. If your wheel was mapped onto gamepads, go to gamepad settings and unmap it. If you used vJoy to map your wheel onto a gamepad before for RPCS3, undo that.</source>
+        <translation>Примечание: НЕ назначайте руль на геймпады — только здесь. Если руль был назначен на геймпады — зайдите в настройки геймпада и уберите назначение. Если ранее использовали vJoy для привязки руля к геймпаду в RPCS3 — отмените это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="655"/>
+        <source>Enabled (requires game restart)</source>
+        <translation>Включено (требуется перезапуск игры)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="658"/>
+        <source>Reverse force feedback effects</source>
+        <translation>Инвертировать эффекты силовой обратной связи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="663"/>
+        <source>Compatibility limit:</source>
+        <translation>Ограничение совместимости:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="666"/>
+        <source>G27 (Default)</source>
+        <translation>G27 (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="667"/>
+        <source>Driving Force GT</source>
+        <translation>Driving Force GT</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="668"/>
+        <source>G25</source>
+        <translation>G25</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="669"/>
+        <source>Driving Force Pro</source>
+        <translation>Driving Force Pro</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="676"/>
+        <source>Use the device with the following mapping for force feedback:</source>
+        <translation>Использовать устройство со следующим назначением для силовой обратной связи:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="677"/>
+        <source>Use the device with the following mapping for LED:</source>
+        <translation>Использовать устройство со следующим назначением для LED:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="691"/>
+        <source>Axes:</source>
+        <translation>Оси:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_logitech_g27_settings_dialog.cpp" line="711"/>
+        <source>Buttons:</source>
+        <translation>Кнопки:</translation>
+    </message>
+</context>
+<context>
+    <name>emulated_pad_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="58"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="58"/>
+        <source>Reset all buttons of all players?</source>
+        <translation>Сбросить все кнопки всех игроков?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="75"/>
+        <source>Configure Emulated Buzz</source>
+        <translation>Настройка эмулируемого Buzz</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="79"/>
+        <source>Configure Emulated Turntable</source>
+        <translation>Настройка эмулируемого DJ-пульта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="83"/>
+        <source>Configure Emulated GHLtar</source>
+        <translation>Настройка эмулируемого GHLtar</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="87"/>
+        <source>Configure Emulated USIO</source>
+        <translation>Настройка эмулируемого USIO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="91"/>
+        <source>Configure Emulated PS Move (Real)</source>
+        <translation>Настройка эмулируемого PS Move (реальный)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="95"/>
+        <source>Configure Emulated PS Move (Fake)</source>
+        <translation>Настройка эмулируемого PS Move (эмулируемый)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="99"/>
+        <source>Configure Emulated PS Move (Mouse)</source>
+        <translation>Настройка эмулируемого PS Move (мышь)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="103"/>
+        <source>Configure Emulated GunCon 3</source>
+        <translation>Настройка эмулируемого GunCon 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="107"/>
+        <source>Configure Emulated Top Shot Elite</source>
+        <translation>Настройка эмулируемого Top Shot Elite</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="111"/>
+        <source>Configure Emulated Top Shot Fearmaster</source>
+        <translation>Настройка эмулируемого Top Shot Fearmaster</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="233"/>
+        <source>Press the &quot;Combo&quot; button in combination with any of the other combo buttons to trigger their related PS Move button.
+This can be useful if your device does not have enough regular buttons.</source>
+        <translation>Нажмите кнопку «Combo» в сочетании с другой combo-кнопкой для активации соответствующей кнопки PS Move.
+Полезно, если у устройства недостаточно обычных кнопок.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="383"/>
+        <source>Current Basic Mouse Config</source>
+        <translation>Текущая конфигурация базовой мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="401"/>
+        <source>Current Raw Mouse Config</source>
+        <translation>Текущая конфигурация мыши (сырой ввод)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/emulated_pad_settings_dialog.cpp" line="415"/>
+        <source>Player %0</source>
+        <translation>Игрок %0</translation>
+    </message>
+</context>
+<context>
+    <name>fatal_error_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/fatal_error_dialog.cpp" line="38"/>
+        <source>HOW TO REPORT ERRORS:</source>
+        <translation>КАК СООБЩАТЬ ОБ ОШИБКАХ:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/fatal_error_dialog.cpp" line="39"/>
+        <source>Please, don&apos;t send incorrect reports. Thanks for understanding.</source>
+        <translation>Пожалуйста, не отправляйте неверные отчёты. Спасибо за понимание.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/fatal_error_dialog.cpp" line="49"/>
+        <source>RPCS3: Fatal Error</source>
+        <translation>RPCS3: Критическая ошибка</translation>
+    </message>
+</context>
+<context>
+    <name>figure_creator_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="409"/>
+        <source>Figure Creator</source>
+        <translation>Создание фигурки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="417"/>
+        <source>Filter by Series:</source>
+        <translation>Фильтр по серии:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="418"/>
+        <source>All</source>
+        <translation>Все</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="419"/>
+        <source>1.0</source>
+        <translation>1.0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="420"/>
+        <source>2.0</source>
+        <translation>2.0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="421"/>
+        <source>3.0</source>
+        <translation>3.0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="477"/>
+        <source>--Unknown--</source>
+        <translation>--Неизвестно--</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="508"/>
+        <source>Figure Number:</source>
+        <translation>Номер фигурки:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="510"/>
+        <source>Series:</source>
+        <translation>Серия:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="523"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="524"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="563"/>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="569"/>
+        <source>Error converting value</source>
+        <translation>Ошибка преобразования значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="563"/>
+        <source>Figure number entered is invalid!</source>
+        <translation>Введён недействительный номер фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="569"/>
+        <source>Series number entered is invalid!</source>
+        <translation>Введён недействительный номер серии!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="582"/>
+        <source>Create Figure File</source>
+        <translation>Создать файл фигурки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="582"/>
+        <source>Infinity Figure (*.bin);;</source>
+        <translation>Infinity Figure (*.bin);;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="589"/>
+        <source>Failed to create figure file!</source>
+        <translation>Не удалось создать файл фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="589"/>
+        <source>Failed to create figure file:
+%1</source>
+        <translation>Не удалось создать файл фигурки:
+%1</translation>
+    </message>
+</context>
+<context>
+    <name>find_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="7"/>
+        <source>Find string</source>
+        <translation>Поиск строки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="10"/>
+        <source>Search...</source>
+        <translation>Поиск...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="12"/>
+        <source>Counted in lines: -</source>
+        <translation>Совпадений в строках: -</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="13"/>
+        <source>Counted in total: -</source>
+        <translation>Всего совпадений: -</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="15"/>
+        <source>First</source>
+        <translation>Первое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="16"/>
+        <source>Last</source>
+        <translation>Последнее</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="17"/>
+        <source>Next</source>
+        <translation>Следующее</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="18"/>
+        <source>Previous</source>
+        <translation>Предыдущее</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="115"/>
+        <source>Counted in lines: %0</source>
+        <translation>Совпадений в строках: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/find_dialog.cpp" line="116"/>
+        <source>Counted in total: %0</source>
+        <translation>Всего совпадений: %0</translation>
+    </message>
+</context>
+<context>
+    <name>game_compatibility</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.cpp" line="221"/>
+        <source>Downloading Database</source>
+        <translation>Загрузка базы данных</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="126"/>
+        <source>Playable</source>
+        <translation>Играбельно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="126"/>
+        <source>Games that can be properly played from start to finish</source>
+        <translation>Игры, которые можно пройти от начала до конца</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="127"/>
+        <source>Ingame</source>
+        <translation>В игре</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="127"/>
+        <source>Games that either can&apos;t be finished, have serious glitches or have insufficient performance</source>
+        <translation>Игры, которые нельзя пройти, имеют серьёзные баги или недостаточную производительность</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="128"/>
+        <source>Intro</source>
+        <translation>Интро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="128"/>
+        <source>Games that display image but don&apos;t make it past the menus</source>
+        <translation>Игры, которые показывают изображение, но не выходят за пределы меню</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="129"/>
+        <source>Loadable</source>
+        <translation>Загружаемо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="129"/>
+        <source>Games that display a black screen with a framerate on the window&apos;s title</source>
+        <translation>Игры, которые показывают чёрный экран с FPS в заголовке окна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="130"/>
+        <source>Nothing</source>
+        <translation>Ничего</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="130"/>
+        <source>Games that don&apos;t initialize properly, not loading at all and/or crashing the emulator</source>
+        <translation>Игры, которые не инициализируются корректно, не загружаются и/или вызывают сбой эмулятора</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="131"/>
+        <source>No results found</source>
+        <translation>Результатов не найдено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="131"/>
+        <source>There is no entry for this game or application in the compatibility database yet.</source>
+        <translation>В базе совместимости пока нет записи для этой игры или приложения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="132"/>
+        <source>Database missing</source>
+        <translation>База данных отсутствует</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="132"/>
+        <source>Right click here and download the current database.
+Make sure you are connected to the internet.</source>
+        <translation>Нажмите правой кнопкой мыши и загрузите текущую базу данных.
+Убедитесь, что подключены к интернету.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="133"/>
+        <source>Retrieving...</source>
+        <translation>Получение...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_compatibility.h" line="133"/>
+        <source>Downloading the compatibility database. Please wait...</source>
+        <translation>Загрузка базы данных совместимости. Пожалуйста, подождите...</translation>
+    </message>
+</context>
+<context>
+    <name>game_list_actions</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="128"/>
+        <source>%0 - %1
+</source>
+        <translation>%0 - %1
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="132"/>
+        <source>
+Disc Game Info:
+Path: %0
+</source>
+        <translation>
+Информация об игре на диске:
+Путь: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="135"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="150"/>
+        <source>Size: %0
+</source>
+        <translation>Размер: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="141"/>
+        <source>
+%0 Info:
+</source>
+        <translation>
+Информация о %0:
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="141"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="285"/>
+        <source>Game Data</source>
+        <translation>Данные игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="145"/>
+        <source>Path: %0
+</source>
+        <translation>Путь: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="155"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="184"/>
+        <source>Total size: %0
+</source>
+        <translation>Общий размер: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="169"/>
+        <source>%0 selected games: %1 Disc Game - %2 not Disc Game
+</source>
+        <translation>%0 выбранных игр: %1 на диске — %2 не на диске
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="172"/>
+        <source>
+Disc Game Info:
+</source>
+        <translation>
+Информация об играх на диске:
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="175"/>
+        <source>VFS unhosted: %0
+</source>
+        <translation>VFS без хоста: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="178"/>
+        <source>VFS hosted: %0
+</source>
+        <translation>VFS с хостом: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="181"/>
+        <source>Total games: %0
+</source>
+        <translation>Всего игр: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="187"/>
+        <source>
+Game Data Info:
+Total size: %0
+</source>
+        <translation>
+Информация о данных игры:
+Общий размер: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="229"/>
+        <source>
+Emulator Data Info:
+Caches size: %0
+</source>
+        <translation>
+Информация о данных эмулятора:
+Размер кэшей: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="230"/>
+        <source>Icons size: %0
+</source>
+        <translation>Размер иконок: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="231"/>
+        <source>Savestates size: %0
+</source>
+        <translation>Размер сохранений: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="232"/>
+        <source>Captures size: %0
+</source>
+        <translation>Размер захватов: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="233"/>
+        <source>Recordings size: %0
+</source>
+        <translation>Размер записей: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="234"/>
+        <source>Screenshots size: %0
+</source>
+        <translation>Размер скриншотов: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="238"/>
+        <source>
+Current free disk space: %0
+</source>
+        <translation>
+Текущее свободное место на диске: %0
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="253"/>
+        <source>Remove title from game list (Disc Game path is not removed!)</source>
+        <translation>Удалить название из списка игр (путь к игре на диске не удаляется!)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="254"/>
+        <source>Remove caches and custom configs</source>
+        <translation>Удалить кэши и пользовательские конфигурации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="255"/>
+        <source>Remove icons and shortcuts</source>
+        <translation>Удалить иконки и ярлыки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="256"/>
+        <source>Remove savestates</source>
+        <translation>Удалить сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="257"/>
+        <source>Remove captures</source>
+        <translation>Удалить захваты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="258"/>
+        <source>Remove recordings</source>
+        <translation>Удалить записи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="259"/>
+        <source>Remove screenshots</source>
+        <translation>Удалить скриншоты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="265"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="271"/>
+        <source>Title located under auto-detection VFS &quot;games&quot; folder cannot be removed</source>
+        <translation>Название из папки VFS &quot;games&quot; с автоопределением не может быть удалено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="284"/>
+        <source>
+Permanently remove %0 and selected (optional) contents from drive?
+</source>
+        <translation>
+Окончательно удалить %0 и выбранное (дополнительное) содержимое с диска?
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="289"/>
+        <source>
+Permanently remove selected (optional) contents from drive?
+</source>
+        <translation>
+Окончательно удалить выбранное (дополнительное) содержимое с диска?
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="295"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="434"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="458"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="527"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1096"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1136"/>
+        <source>Confirm Removal</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="346"/>
+        <source>Failure!</source>
+        <translation>Ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="347"/>
+        <source>Failed to remove %0 from drive!
+Caches and custom configs have been left intact.</source>
+        <translation>Не удалось удалить %0 с диска!
+Кэши и пользовательские конфигурации остались нетронутыми.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="348"/>
+        <source>Failed to remove %0 from drive!</source>
+        <translation>Не удалось удалить %0 с диска!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="364"/>
+        <source>Game Info</source>
+        <translation>Информация об игре</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="384"/>
+        <source>
+    %0: %1</source>
+        <translation>
+    %0: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="389"/>
+        <source>
+  VFS disk usage: %0%1</source>
+        <translation>
+  Использование VFS на диске: %0%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="391"/>
+        <source>
+  Cache disk usage: %0</source>
+        <translation>
+  Использование кэша на диске: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="397"/>
+        <source>Disk usage</source>
+        <translation>Использование диска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="427"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="449"/>
+        <source>Removal Aborted</source>
+        <translation>Удаление отменено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="428"/>
+        <source>Removal of %0 not allowed due to %1 title is running!</source>
+        <translation>Удаление %0 невозможно, так как запущен %1!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="434"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="458"/>
+        <source>Remove %0?</source>
+        <translation>Удалить %0?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="450"/>
+        <source>Removal of %0 not allowed due to emulator is running!</source>
+        <translation>Удаление %0 невозможно, так как эмулятор запущен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="514"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="555"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1554"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="514"/>
+        <source>Failed to remove configuration file!</source>
+        <translation>Не удалось удалить файл конфигурации!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="528"/>
+        <source>Remove custom gamepad configuration?
+Your configuration will revert to the global pad settings.</source>
+        <translation>Удалить пользовательскую конфигурацию геймпада?
+Конфигурация будет сброшена до глобальных настроек.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="529"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1136"/>
+        <source>Remove custom gamepad configuration?</source>
+        <translation>Удалить пользовательскую конфигурацию геймпада?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="555"/>
+        <source>Failed to completely remove gamepad configuration directory!</source>
+        <translation>Не удалось полностью удалить папку конфигурации геймпада!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="955"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="993"/>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1017"/>
+        <source>Confirm Creation</source>
+        <translation>Подтверждение создания</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1017"/>
+        <source>Create LLVM cache?</source>
+        <translation>Создать кэш LLVM?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1038"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1049"/>
+        <source>LLVM Cache Batch Creation</source>
+        <translation>Массовое создание кэша LLVM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1038"/>
+        <source>No titles found</source>
+        <translation>Названия не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1047"/>
+        <source>Creating all LLVM caches</source>
+        <translation>Создание всех кэшей LLVM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1049"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1119"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1159"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1201"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1243"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1286"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1329"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1372"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1421"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1062"/>
+        <source>%0
+Progress: %1/%2 caches compiled</source>
+        <translation>%0
+Прогресс: %1/%2 кэшей скомпилировано</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1096"/>
+        <source>Remove custom configuration?</source>
+        <translation>Удалить пользовательскую конфигурацию?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1115"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1119"/>
+        <source>Custom Configuration Batch Removal</source>
+        <translation>Массовое удаление пользовательских конфигураций</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1115"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1155"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1197"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1239"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1282"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1325"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1368"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1415"/>
+        <source>No files found</source>
+        <translation>Файлы не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1119"/>
+        <source>Removing all custom configurations</source>
+        <translation>Удаление всех пользовательских конфигураций</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1124"/>
+        <source>%0/%1 custom configurations cleared</source>
+        <translation>%0/%1 пользовательских конфигураций очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1155"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1159"/>
+        <source>Custom Gamepad Configuration Batch Removal</source>
+        <translation>Массовое удаление конфигураций геймпадов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1159"/>
+        <source>Removing all custom gamepad configurations</source>
+        <translation>Удаление всех пользовательских конфигураций геймпадов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1164"/>
+        <source>%0/%1 custom gamepad configurations cleared</source>
+        <translation>%0/%1 конфигураций геймпадов очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1197"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1201"/>
+        <source>Shader Cache Batch Removal</source>
+        <translation>Массовое удаление кэша шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1201"/>
+        <source>Removing all shader caches</source>
+        <translation>Удаление всех кэшей шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1206"/>
+        <source>%0/%1 shader caches cleared</source>
+        <translation>%0/%1 кэшей шейдеров очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1239"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1243"/>
+        <source>PPU Cache Batch Removal</source>
+        <translation>Массовое удаление кэша PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1243"/>
+        <source>Removing all PPU caches</source>
+        <translation>Удаление всех кэшей PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1248"/>
+        <source>%0/%1 PPU caches cleared</source>
+        <translation>%0/%1 кэшей PPU очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1282"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1286"/>
+        <source>SPU Cache Batch Removal</source>
+        <translation>Массовое удаление кэша SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1286"/>
+        <source>Removing all SPU caches</source>
+        <translation>Удаление всех кэшей SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1291"/>
+        <source>%0/%1 SPU caches cleared</source>
+        <translation>%0/%1 кэшей SPU очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1325"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1329"/>
+        <source>HDD1 Cache Batch Removal</source>
+        <translation>Массовое удаление кэша HDD1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1329"/>
+        <source>Removing all HDD1 caches</source>
+        <translation>Удаление всех кэшей HDD1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1334"/>
+        <source>%0/%1 HDD1 caches cleared</source>
+        <translation>%0/%1 кэшей HDD1 очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1368"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1372"/>
+        <source>Cache Batch Removal</source>
+        <translation>Массовое удаление кэшей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1372"/>
+        <source>Removing all caches</source>
+        <translation>Удаление всех кэшей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1377"/>
+        <source>%0/%1 caches cleared</source>
+        <translation>%0/%1 кэшей очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1415"/>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1421"/>
+        <source>Content Batch Removal</source>
+        <translation>Массовое удаление содержимого</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1421"/>
+        <source>Removing all contents</source>
+        <translation>Удаление всего содержимого</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1426"/>
+        <source>%0/%1 contents cleared</source>
+        <translation>%0/%1 элементов очищено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1550"/>
+        <source>Success!</source>
+        <translation>Успешно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1550"/>
+        <source>Successfully created shortcut(s).</source>
+        <translation>Ярлык(и) успешно созданы.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_actions.cpp" line="1554"/>
+        <source>Failed to create one or more shortcuts!</source>
+        <translation>Не удалось создать один или несколько ярлыков!</translation>
+    </message>
+</context>
+<context>
+    <name>game_list_context_menu</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="69"/>
+        <source>&amp;Reboot with Global Configuration</source>
+        <translation>&amp;Перезапустить с глобальной конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="70"/>
+        <source>&amp;Boot with Global Configuration</source>
+        <translation>&amp;Запустить с глобальной конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="72"/>
+        <source>&amp;Reboot</source>
+        <translation>&amp;Перезапустить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="73"/>
+        <source>&amp;Boot</source>
+        <translation>&amp;Запустить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="81"/>
+        <source>&amp;Reboot with Custom Configuration</source>
+        <translation>&amp;Перезапустить с пользовательской конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="82"/>
+        <source>&amp;Boot with Custom Configuration</source>
+        <translation>&amp;Запустить с пользовательской конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="99"/>
+        <source>&amp;Reboot with Default Configuration</source>
+        <translation>&amp;Перезапустить с конфигурацией по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="100"/>
+        <source>&amp;Boot with Default Configuration</source>
+        <translation>&amp;Запустить с конфигурацией по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="109"/>
+        <source>&amp;Reboot with Manually Selected Configuration</source>
+        <translation>&amp;Перезапустить с выбранной конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="110"/>
+        <source>&amp;Boot with Manually Selected Configuration</source>
+        <translation>&amp;Запустить с выбранной конфигурацией</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="114"/>
+        <source>Config Files (*.yml);;All files (*.*)</source>
+        <translation>Файлы конфигурации (*.yml);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="133"/>
+        <source>&amp;Reboot with last SaveState</source>
+        <translation>&amp;Перезапустить с последним сохранением</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="134"/>
+        <source>&amp;Boot with last SaveState</source>
+        <translation>&amp;Запустить с последним сохранением</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="145"/>
+        <source>&amp;Choose SaveState to reboot</source>
+        <translation>&amp;Выбрать сохранение для перезапуска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="146"/>
+        <source>&amp;Choose SaveState to boot</source>
+        <translation>&amp;Выбрать сохранение для запуска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="159"/>
+        <source>&amp;Change Custom Configuration</source>
+        <translation>&amp;Изменить пользовательскую конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="160"/>
+        <source>&amp;Create Custom Configuration From Global Settings</source>
+        <translation>&amp;Создать пользов. конфигурацию из глобальных настроек</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="162"/>
+        <source>&amp;Create Custom Configuration From Default Settings</source>
+        <translation>&amp;Создать пользов. конфигурацию из настроек по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="164"/>
+        <source>&amp;Change Custom Gamepad Configuration</source>
+        <translation>&amp;Изменить пользовательскую конфигурацию геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="165"/>
+        <source>&amp;Create Custom Gamepad Configuration</source>
+        <translation>&amp;Создать пользовательскую конфигурацию геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="166"/>
+        <source>&amp;Manage Game Patches</source>
+        <translation>&amp;Управление патчами игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="171"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="751"/>
+        <source>&amp;Create LLVM Cache</source>
+        <translation>&amp;Создать кэш LLVM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="174"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="758"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="178"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="760"/>
+        <source>&amp;Remove Custom Configuration</source>
+        <translation>&amp;Удалить пользовательскую конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="189"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="766"/>
+        <source>&amp;Remove Custom Gamepad Configuration</source>
+        <translation>&amp;Удалить пользовательскую конфигурацию геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="207"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="774"/>
+        <source>&amp;Remove Shader Cache</source>
+        <translation>&amp;Удалить кэш шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="214"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="780"/>
+        <source>&amp;Remove PPU Cache</source>
+        <translation>&amp;Удалить кэш PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="221"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="786"/>
+        <source>&amp;Remove SPU Cache</source>
+        <translation>&amp;Удалить кэш SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="231"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="792"/>
+        <source>&amp;Remove HDD1 Cache</source>
+        <translation>&amp;Удалить кэш HDD1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="241"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="798"/>
+        <source>&amp;Remove All Caches</source>
+        <translation>&amp;Удалить все кэши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="253"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="806"/>
+        <source>&amp;Remove Savestates</source>
+        <translation>&amp;Удалить сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="268"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="819"/>
+        <source>&amp;Manage Game</source>
+        <translation>&amp;Управление игрой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="271"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="822"/>
+        <source>&amp;Create Desktop Shortcut</source>
+        <translation>&amp;Создать ярлык на рабочем столе</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="277"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="832"/>
+        <source>&amp;Create Start Menu Shortcut</source>
+        <translation>&amp;Создать ярлык в меню «Пуск»</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="279"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="834"/>
+        <source>&amp;Create Launchpad Shortcut</source>
+        <translation>&amp;Создать ярлык в Launchpad</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="281"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="836"/>
+        <source>&amp;Create Application Menu Shortcut</source>
+        <translation>&amp;Создать ярлык в меню приложений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="291"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="849"/>
+        <source>&amp;Hide In Game List</source>
+        <translation>&amp;Скрыть в списке игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="294"/>
+        <source>&amp;Rename In Game List</source>
+        <translation>&amp;Переименовать в списке игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="297"/>
+        <source>&amp;Edit Tooltip Notes</source>
+        <translation>&amp;Редактировать заметки подсказки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="298"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="880"/>
+        <source>&amp;Reset Time Played</source>
+        <translation>&amp;Сбросить время игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="303"/>
+        <source>&amp;Remove %1</source>
+        <translation>&amp;Удалить %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="307"/>
+        <source>&amp;Custom Images</source>
+        <translation>&amp;Пользовательские изображения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="310"/>
+        <source>&amp;Import Custom Icon</source>
+        <translation>&amp;Импортировать пользовательскую иконку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="311"/>
+        <source>&amp;Replace Custom Icon</source>
+        <translation>&amp;Заменить пользовательскую иконку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="312"/>
+        <source>&amp;Remove Custom Icon</source>
+        <translation>&amp;Удалить пользовательскую иконку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="317"/>
+        <source>&amp;Import Hover Gif</source>
+        <translation>&amp;Импортировать Hover GIF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="318"/>
+        <source>&amp;Replace Hover Gif</source>
+        <translation>&amp;Заменить Hover GIF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="319"/>
+        <source>&amp;Remove Hover Gif</source>
+        <translation>&amp;Удалить Hover GIF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="324"/>
+        <source>&amp;Import Custom Shader Loading Background</source>
+        <translation>&amp;Импортировать фон загрузки шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="325"/>
+        <source>&amp;Replace Custom Shader Loading Background</source>
+        <translation>&amp;Заменить фон загрузки шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="326"/>
+        <source>&amp;Remove Custom Shader Loading Background</source>
+        <translation>&amp;Удалить фон загрузки шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="355"/>
+        <source>Select Custom Icon</source>
+        <translation>Выбрать пользовательскую иконку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="358"/>
+        <source>Select Custom Hover Gif</source>
+        <translation>Выбрать пользовательский Hover GIF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="361"/>
+        <source>Select Custom Shader Loading Background</source>
+        <translation>Выбрать фон загрузки шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="364"/>
+        <source>%0 (*.%0);;All files (*.*)</source>
+        <translation>%0 (*.%0);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="374"/>
+        <source>Remove Custom Icon of %0?</source>
+        <translation>Удалить пользовательскую иконку %0?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="377"/>
+        <source>Remove Custom Hover Gif of %0?</source>
+        <translation>Удалить пользовательский Hover GIF %0?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="380"/>
+        <source>Remove Custom Shader Loading Background of %0?</source>
+        <translation>Удалить фон загрузки шейдеров %0?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="385"/>
+        <source>Confirm Removal</source>
+        <translation>Подтвердить удаление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="390"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="406"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="390"/>
+        <source>Failed to remove the old file!</source>
+        <translation>Не удалось удалить старый файл!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="406"/>
+        <source>Failed to import the new file!</source>
+        <translation>Не удалось импортировать новый файл!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="454"/>
+        <source>&amp;Open Folder</source>
+        <translation>&amp;Открыть папку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="465"/>
+        <source>&amp;Open Disc Game Folder</source>
+        <translation>&amp;Открыть папку диска с игрой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="481"/>
+        <source>&amp;Open %0 Folder</source>
+        <translation>&amp;Открыть папку %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="481"/>
+        <source>Game Data</source>
+        <translation>Данные игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="493"/>
+        <source>&amp;Open Custom Config Folder</source>
+        <translation>&amp;Открыть папку пользовательской конфигурации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="506"/>
+        <source>&amp;Open Cache Folder</source>
+        <translation>&amp;Открыть папку кэша</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="515"/>
+        <source>&amp;Open Data Folder</source>
+        <translation>&amp;Открыть папку данных</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="524"/>
+        <source>&amp;Open Savestates Folder</source>
+        <translation>&amp;Открыть папку сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="533"/>
+        <source>&amp;Open Captures Folder</source>
+        <translation>&amp;Открыть папку захватов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="542"/>
+        <source>&amp;Open Recordings Folder</source>
+        <translation>&amp;Открыть папку записей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="551"/>
+        <source>&amp;Open Screenshots Folder</source>
+        <translation>&amp;Открыть папку скриншотов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="559"/>
+        <source>&amp;Copy Info</source>
+        <translation>&amp;Копировать информацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="560"/>
+        <source>&amp;Copy Name + Serial</source>
+        <translation>&amp;Копировать название + серийный номер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="561"/>
+        <source>&amp;Copy Name</source>
+        <translation>&amp;Копировать название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="562"/>
+        <source>&amp;Copy Serial</source>
+        <translation>&amp;Копировать серийный номер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="566"/>
+        <source>&amp;Check Game Compatibility</source>
+        <translation>&amp;Проверить совместимость игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="567"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="908"/>
+        <source>&amp;Download Compatibility Database</source>
+        <translation>&amp;Скачать базу совместимости</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="572"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="917"/>
+        <source>&amp;Disk Usage</source>
+        <translation>&amp;Использование диска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="579"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="924"/>
+        <source>&amp;Game Info</source>
+        <translation>&amp;Информация об игре</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="668"/>
+        <source>Rename Title</source>
+        <translation>Переименовать название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="668"/>
+        <source>%0
+%1
+
+You can clear the line in order to use the original title.</source>
+        <translation>%0
+%1
+
+Очистите строку, чтобы использовать оригинальное название.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="692"/>
+        <source>Edit Tooltip Notes</source>
+        <translation>Редактировать заметки подсказки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="692"/>
+        <source>%0
+%1</source>
+        <translation>%0
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="711"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="883"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="711"/>
+        <source>Reset time played?
+
+%0 [%1]</source>
+        <translation>Сбросить время игры?
+
+%0 [%1]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="825"/>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="840"/>
+        <source>Confirm Creation</source>
+        <translation>Подтвердить создание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="825"/>
+        <source>Create desktop shortcut?</source>
+        <translation>Создать ярлык на рабочем столе?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="840"/>
+        <source>Create shortcut?</source>
+        <translation>Создать ярлык?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="852"/>
+        <source>Confirm Hiding</source>
+        <translation>Подтвердить скрытие</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="852"/>
+        <source>Hide in game list?</source>
+        <translation>Скрыть в списке игр?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="865"/>
+        <source>&amp;Show In Game List</source>
+        <translation>&amp;Показать в списке игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="883"/>
+        <source>Reset time played?</source>
+        <translation>Сбросить время игры?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_context_menu.cpp" line="900"/>
+        <source>&amp;Remove Game</source>
+        <translation>&amp;Удалить игру</translation>
+    </message>
+</context>
+<context>
+    <name>game_list_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="38"/>
+        <source>Game List</source>
+        <translation>Список игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="114"/>
+        <source>Loading games</source>
+        <translation>Загрузка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="114"/>
+        <source>Loading games, please wait...</source>
+        <translation>Загрузка игр, подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="114"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="197"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="197"/>
+        <source>Failed to retrieve the online compatibility database!
+Falling back to local database.
+
+%0</source>
+        <translation>Не удалось загрузить онлайн-базу совместимости!
+Используется локальная база.
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="234"/>
+        <source>Icon</source>
+        <translation>Иконка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="235"/>
+        <source>Name</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="236"/>
+        <source>Serial</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="237"/>
+        <source>Firmware</source>
+        <translation>Прошивка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="238"/>
+        <source>Version</source>
+        <translation>Версия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="239"/>
+        <source>Category</source>
+        <translation>Категория</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="240"/>
+        <source>Path</source>
+        <translation>Путь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="241"/>
+        <source>PlayStation Move</source>
+        <translation>PlayStation Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="242"/>
+        <source>Supported Resolutions</source>
+        <translation>Поддерживаемые разрешения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="243"/>
+        <source>Sound Formats</source>
+        <translation>Форматы звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="244"/>
+        <source>Parental Level</source>
+        <translation>Родительский контроль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="245"/>
+        <source>Last Played</source>
+        <translation>Последний запуск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="246"/>
+        <source>Time Played</source>
+        <translation>Время игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="247"/>
+        <source>Compatibility</source>
+        <translation>Совместимость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="248"/>
+        <source>Space On Disk</source>
+        <translation>Место на диске</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="258"/>
+        <source>Show Icons</source>
+        <translation>Показывать иконки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="259"/>
+        <source>Show Names</source>
+        <translation>Показывать названия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="260"/>
+        <source>Show Serials</source>
+        <translation>Показывать серийные номера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="261"/>
+        <source>Show Firmwares</source>
+        <translation>Показывать прошивки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="262"/>
+        <source>Show Versions</source>
+        <translation>Показывать версии</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="263"/>
+        <source>Show Categories</source>
+        <translation>Показывать категории</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="264"/>
+        <source>Show Paths</source>
+        <translation>Показывать пути</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="265"/>
+        <source>Show PlayStation Move</source>
+        <translation>Показывать PlayStation Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="266"/>
+        <source>Show Supported Resolutions</source>
+        <translation>Показывать поддерживаемые разрешения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="267"/>
+        <source>Show Sound Formats</source>
+        <translation>Показывать форматы звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="268"/>
+        <source>Show Parental Levels</source>
+        <translation>Показывать уровни родительского контроля</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="269"/>
+        <source>Show Last Played</source>
+        <translation>Показывать последний запуск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="270"/>
+        <source>Show Time Played</source>
+        <translation>Показывать время игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="271"/>
+        <source>Show Compatibility</source>
+        <translation>Показывать совместимость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_frame.cpp" line="272"/>
+        <source>Show Space On Disk</source>
+        <translation>Показывать место на диске</translation>
+    </message>
+</context>
+<context>
+    <name>game_list_grid</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_grid.cpp" line="79"/>
+        <source>%0 [%1]
+
+Notes:
+%2</source>
+        <translation>%0 [%1]
+
+Заметки:
+%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_grid.cpp" line="83"/>
+        <source>%0 [%1]</source>
+        <translation>%0 [%1]</translation>
+    </message>
+</context>
+<context>
+    <name>game_list_table</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="52"/>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="393"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="324"/>
+        <source>%0 [%1]
+
+Notes:
+%2</source>
+        <translation>%0 [%1]
+
+Заметки:
+%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="356"/>
+        <source>%0 (Update available: %1)</source>
+        <translation>%0 (Доступно обновление: %1)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="386"/>
+        <source>Supported</source>
+        <translation>Поддерживается</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="386"/>
+        <source>Not Supported</source>
+        <translation>Не поддерживается</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/game_list_table.cpp" line="391"/>
+        <source>Never played</source>
+        <translation>Никогда не запускалась</translation>
+    </message>
+</context>
+<context>
+    <name>gs_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="483"/>
+        <source>Recording saved: %0</source>
+        <translation>Запись сохранена: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="558"/>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="571"/>
+        <source>Recording not possible</source>
+        <translation>Запись невозможна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="584"/>
+        <source>Recording started</source>
+        <translation>Запись начата</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="1115"/>
+        <source>Screenshot saved: %0</source>
+        <translation>Снимок экрана сохранён: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="1199"/>
+        <source>Exit Game?</source>
+        <translation>Выйти из игры?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gs_frame.cpp" line="1200"/>
+        <source>Do you really want to exit the game?&lt;br&gt;&lt;br&gt;Any unsaved progress will be lost!&lt;br&gt;</source>
+        <translation>Вы действительно хотите выйти из игры?&lt;br&gt;&lt;br&gt;Несохранённый прогресс будет потерян!&lt;br&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>gui_application</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="107"/>
+        <source>Experimental Build Warning</source>
+        <translation>Предупреждение об экспериментальной сборке</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="112"/>
+        <source>Please understand that this build is not an official RPCS3 release.
+This build contains changes that may break games, or even &lt;b&gt;damage&lt;/b&gt; your data.
+We recommend to download and use the official build from the %0.
+
+Build origin: %1
+Do you wish to use this build anyway?</source>
+        <translation>Обратите внимание, что эта сборка не является официальным релизом RPCS3.
+Она содержит изменения, которые могут нарушить работу игр или &lt;b&gt;повредить&lt;/b&gt; ваши данные.
+Рекомендуем скачать и использовать официальную сборку с %0.
+
+Источник сборки: %1
+Всё равно использовать эту сборку?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="119"/>
+        <source>RPCS3 website</source>
+        <translation>сайта RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="190"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="191"/>
+        <source>The current limit of maximum file descriptors is too low.
+Some games will crash.
+
+Please increase the limit before running RPCS3.</source>
+        <translation>Текущий лимит файловых дескрипторов слишком мал.
+Некоторые игры будут вылетать.
+
+Пожалуйста, увеличьте лимит перед запуском RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="847"/>
+        <source>Stopping emulator took too long.
+Some thread has probably deadlocked. Aborting.</source>
+        <translation>Остановка эмулятора заняла слишком много времени.
+Вероятно, один из потоков завис. Прерывание.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="860"/>
+        <source>PS3 Game/Application Is Unresponsive</source>
+        <translation>Игра/приложение PS3 не отвечает</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="864"/>
+        <source>Terminate RPCS3</source>
+        <translation>Завершить RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="865"/>
+        <source>Keep Waiting</source>
+        <translation>Продолжить ожидание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="867"/>
+        <source>Waiting for %0 second(s) already to stop emulation without success.
+Keep waiting or terminate RPCS3 unsafely at your own risk?</source>
+        <translation>Ожидание остановки эмуляции уже %0 сек. без результата.
+Продолжить ожидание или принудительно завершить RPCS3?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="906"/>
+        <source>Creating Save-State / Do Not Close RPCS3</source>
+        <translation>Создание сохранения — не закрывайте RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="906"/>
+        <source>Please wait...</source>
+        <translation>Подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="906"/>
+        <source>Hide Progress</source>
+        <translation>Скрыть прогресс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="911"/>
+        <source>%0 written, %1 second(s) passed%2</source>
+        <translation>Записано %0, прошло %1 сек.%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_application.cpp" line="970"/>
+        <source>If Stuck, Report To Developers</source>
+        <translation>Если завис — сообщите разработчикам</translation>
+    </message>
+</context>
+<context>
+    <name>gui_settings</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="160"/>
+        <source>Don&apos;t show again</source>
+        <translation>Больше не показывать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="213"/>
+        <source>Close Running Game?</source>
+        <translation>Закрыть запущенную игру?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="214"/>
+        <source>Performing this action will close the current game.&lt;br&gt;Do you really want to continue?&lt;br&gt;&lt;br&gt;Any unsaved progress will be lost!&lt;br&gt;</source>
+        <translation>Это действие закроет текущую игру.&lt;br&gt;Вы действительно хотите продолжить?&lt;br&gt;&lt;br&gt;Несохранённый прогресс будет потерян!&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="218"/>
+        <source>Booting another game will close the current game.&lt;br&gt;Do you really want to boot another game?&lt;br&gt;&lt;br&gt;Any unsaved progress will be lost!&lt;br&gt;</source>
+        <translation>Запуск другой игры закроет текущую.&lt;br&gt;Вы действительно хотите запустить другую игру?&lt;br&gt;&lt;br&gt;Несохранённый прогресс будет потерян!&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="222"/>
+        <source>Exit RPCS3?</source>
+        <translation>Выйти из RPCS3?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/gui_settings.cpp" line="223"/>
+        <source>A game is currently running. Do you really want to close RPCS3?&lt;br&gt;&lt;br&gt;Any unsaved progress will be lost!&lt;br&gt;</source>
+        <translation>Игра запущена. Вы действительно хотите закрыть RPCS3?&lt;br&gt;&lt;br&gt;Несохранённый прогресс будет потерян!&lt;br&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>headless_application</name>
+    <message>
+        <location filename="rpcs3/headless_application.cpp" line="155"/>
+        <source>Stopping emulator took too long.
+Some thread has probably deadlocked. Aborting.</source>
+        <translation>Остановка эмулятора заняла слишком много времени.
+Вероятно, один из потоков завис. Прерывание.</translation>
+    </message>
+</context>
+<context>
+    <name>infinity_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="718"/>
+        <source>Infinity Manager</source>
+        <translation>Менеджер Infinity</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="733"/>
+        <source>Active Infinity Figures:</source>
+        <translation>Активные фигурки Infinity:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="736"/>
+        <source>Play Set/Power Disc</source>
+        <translation>Игровой набор/Power Disc</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="738"/>
+        <source>Power Disc Two</source>
+        <translation>Power Disc два</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="740"/>
+        <source>Power Disc Three</source>
+        <translation>Power Disc три</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="742"/>
+        <source>Player One</source>
+        <translation>Игрок один</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="744"/>
+        <source>Player One Ability One</source>
+        <translation>Способность игрока один — первая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="746"/>
+        <source>Player One Ability Two</source>
+        <translation>Способность игрока один — вторая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="748"/>
+        <source>Player Two</source>
+        <translation>Игрок два</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="750"/>
+        <source>Player Two Ability One</source>
+        <translation>Способность игрока два — первая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="752"/>
+        <source>Player Two Ability Two</source>
+        <translation>Способность игрока два — вторая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="780"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="781"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="782"/>
+        <source>Load</source>
+        <translation>Загрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="795"/>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="887"/>
+        <source>Unknown Figure</source>
+        <translation>Неизвестная фигурка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="800"/>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="833"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="850"/>
+        <source>Select Infinity File</source>
+        <translation>Выбрать файл Infinity</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="850"/>
+        <source>Infinity Figure (*.bin);;</source>
+        <translation>Фигурка Infinity (*.bin);;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="866"/>
+        <source>Failed to open the figure file!</source>
+        <translation>Не удалось открыть файл фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="866"/>
+        <source>Failed to open the figure file(%1)!
+File may already be in use on the base.</source>
+        <translation>Не удалось открыть файл фигурки (%1)!
+Файл уже может использоваться базой.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="873"/>
+        <source>Failed to read the figure file!</source>
+        <translation>Не удалось прочитать файл фигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/infinity_dialog.cpp" line="873"/>
+        <source>Failed to read the figure file(%1)!
+File was too small.</source>
+        <translation>Не удалось прочитать файл фигурки (%1)!
+Файл слишком мал.</translation>
+    </message>
+</context>
+<context>
+    <name>instruction_editor_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="25"/>
+        <source>Edit instruction</source>
+        <translation>Редактировать инструкцию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="39"/>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="40"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="54"/>
+        <source>Address:     </source>
+        <translation>Адрес:     </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="55"/>
+        <source>Instruction: </source>
+        <translation>Инструкция: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="56"/>
+        <source>Preview:     </source>
+        <translation>Предпросмотр:     </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="65"/>
+        <source>Block Info:  </source>
+        <translation>Инфо о блоке:  </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="78"/>
+        <source>For SPUs Group</source>
+        <translation>Для группы SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="114"/>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="124"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="114"/>
+        <source>Failed to parse PPU instruction.</source>
+        <translation>Не удалось разобрать инструкцию PPU.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="124"/>
+        <source>Failed to patch PPU instruction.</source>
+        <translation>Не удалось пропатчить инструкцию PPU.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/instruction_editor_dialog.cpp" line="163"/>
+        <source>Could not parse instruction.</source>
+        <translation>Не удалось разобрать инструкцию.</translation>
+    </message>
+</context>
+<context>
+    <name>ipc_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ipc_settings_dialog.cpp" line="19"/>
+        <source>IPC Settings</source>
+        <translation>Настройки IPC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ipc_settings_dialog.cpp" line="25"/>
+        <source>Enable IPC Server</source>
+        <translation>Включить IPC-сервер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ipc_settings_dialog.cpp" line="27"/>
+        <source>IPC Server Port</source>
+        <translation>Порт IPC-сервера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ipc_settings_dialog.cpp" line="52"/>
+        <source>Invalid port</source>
+        <translation>Неверный порт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ipc_settings_dialog.cpp" line="52"/>
+        <source>The server port must be an integer in the range 1025 - 65535!</source>
+        <translation>Порт сервера должен быть целым числом от 1025 до 65535!</translation>
+    </message>
+</context>
+<context>
+    <name>kamen_rider_creator_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="154"/>
+        <source>Kamen Rider Creator</source>
+        <translation>Создатель Kamen Rider</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="180"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="181"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="203"/>
+        <source>Create Kamen Rider File</source>
+        <translation>Создать файл Kamen Rider</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="203"/>
+        <source>Kamen Rider Object (*.bin);;All Files (*)</source>
+        <translation>Объект Kamen Rider (*.bin);;Все файлы (*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="212"/>
+        <source>Failed to create kamen rider file!</source>
+        <translation>Не удалось создать файл Kamen Rider!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="212"/>
+        <source>Failed to create kamen rider file:
+%1</source>
+        <translation>Не удалось создать файл Kamen Rider:
+%1</translation>
+    </message>
+</context>
+<context>
+    <name>kamen_rider_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="263"/>
+        <source>Kamen Rider Manager</source>
+        <translation>Менеджер Kamen Rider</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="278"/>
+        <source>Active Kamen Riders:</source>
+        <translation>Активные Kamen Riders:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="289"/>
+        <source>Kamen Rider %1</source>
+        <translation>Kamen Rider %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="293"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="294"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="295"/>
+        <source>Load</source>
+        <translation>Загрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="361"/>
+        <source>Select Kamen Rider File</source>
+        <translation>Выбрать файл Kamen Rider</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="361"/>
+        <source>Kamen Rider (*.bin);;All Files (*)</source>
+        <translation>Kamen Rider (*.bin);;Все файлы (*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="377"/>
+        <source>Failed to open the kamen rider file!</source>
+        <translation>Не удалось открыть файл Kamen Rider!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="377"/>
+        <source>Failed to open the kamen rider file(%1)!
+File may already be in use on the portal.</source>
+        <translation>Не удалось открыть файл Kamen Rider (%1)!
+Файл уже может использоваться порталом.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="384"/>
+        <source>Failed to read the kamen rider file!</source>
+        <translation>Не удалось прочитать файл Kamen Rider!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="384"/>
+        <source>Failed to read the kamen rider file(%1)!
+File was too small.</source>
+        <translation>Не удалось прочитать файл Kamen Rider (%1)!
+Файл слишком мал.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="413"/>
+        <source>Unknown (%1)</source>
+        <translation>Неизвестно (%1)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kamen_rider_dialog.cpp" line="418"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+</context>
+<context>
+    <name>kernel_explorer</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="174"/>
+        <source>Kernel Explorer | %1</source>
+        <translation>Обозреватель ядра | %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="181"/>
+        <source>Refresh</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="182"/>
+        <source>Log All</source>
+        <translation>Записать всё в лог</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="190"/>
+        <source>Kernel</source>
+        <translation>Ядро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="223"/>
+        <source>Process Info</source>
+        <translation>Информация о процессе</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="225"/>
+        <source>Shared Memory</source>
+        <translation>Общая память</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="226"/>
+        <source>Virtual Memory</source>
+        <translation>Виртуальная память</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="227"/>
+        <source>Mutexes</source>
+        <translation>Мьютексы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="228"/>
+        <source>Condition Variables</source>
+        <translation>Условные переменные</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="229"/>
+        <source>Reader Writer Locks</source>
+        <translation>Блокировки чтения/записи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="230"/>
+        <source>Interrupt Tags</source>
+        <translation>Теги прерываний</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="231"/>
+        <source>Interrupt Service Handles</source>
+        <translation>Дескрипторы прерываний</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="232"/>
+        <source>Event Queues</source>
+        <translation>Очереди событий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="233"/>
+        <source>Event Ports</source>
+        <translation>Порты событий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="234"/>
+        <source>Traces</source>
+        <translation>Трассировки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="235"/>
+        <source>SPU Images</source>
+        <translation>Образы SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="236"/>
+        <source>PRX Modules</source>
+        <translation>Модули PRX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="237"/>
+        <source>SPU Ports</source>
+        <translation>Порты SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="238"/>
+        <source>Overlay Modules</source>
+        <translation>Оверлейные модули</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="239"/>
+        <source>Light Weight Mutexes</source>
+        <translation>Лёгкие мьютексы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="240"/>
+        <source>Timers</source>
+        <translation>Таймеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="241"/>
+        <source>Semaphores</source>
+        <translation>Семафоры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="242"/>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="253"/>
+        <source>File Descriptors</source>
+        <translation>Файловые дескрипторы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="243"/>
+        <source>Light Weight Condition Variables</source>
+        <translation>Лёгкие условные переменные</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="244"/>
+        <source>Event Flags</source>
+        <translation>Флаги событий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="245"/>
+        <source>RSXAudio Objects</source>
+        <translation>Объекты RSXAudio</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="247"/>
+        <source>Memory Containers</source>
+        <translation>Контейнеры памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="248"/>
+        <source>PPU Threads</source>
+        <translation>Потоки PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="249"/>
+        <source>SPU Threads</source>
+        <translation>Потоки SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="250"/>
+        <source>SPU Thread Groups</source>
+        <translation>Группы потоков SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="251"/>
+        <source>RSX Contexts</source>
+        <translation>Контексты RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="252"/>
+        <source>Sockets</source>
+        <translation>Сокеты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="776"/>
+        <source>SPURS %1</source>
+        <translation>SPURS %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="851"/>
+        <source>IO-EA Table</source>
+        <translation>Таблица IO-EA</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="852"/>
+        <source>Zcull Bindings</source>
+        <translation>Привязки Zcull</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/kernel_explorer.cpp" line="853"/>
+        <source>Display Buffers</source>
+        <translation>Буферы дисплея</translation>
+    </message>
+</context>
+<context>
+    <name>localized_emu</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="9"/>
+        <source>D-Pad Up</source>
+        <translation>D-Pad вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="10"/>
+        <source>D-Pad Down</source>
+        <translation>D-Pad вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="11"/>
+        <source>D-Pad Left</source>
+        <translation>D-Pad влево</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="12"/>
+        <source>D-Pad Right</source>
+        <translation>D-Pad вправо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="13"/>
+        <source>Select</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="14"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="15"/>
+        <source>PS</source>
+        <translation>PS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="16"/>
+        <source>Triangle</source>
+        <translation>Triangle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="17"/>
+        <source>Circle</source>
+        <translation>Circle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="18"/>
+        <source>Square</source>
+        <translation>Square</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="19"/>
+        <source>Cross</source>
+        <translation>Cross</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="20"/>
+        <source>L1</source>
+        <translation>L1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="21"/>
+        <source>R1</source>
+        <translation>R1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="22"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="23"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="24"/>
+        <source>L3</source>
+        <translation>L3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="25"/>
+        <source>R3</source>
+        <translation>R3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="26"/>
+        <source>Left Stick Up</source>
+        <translation>Левый стик вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="27"/>
+        <source>Left Stick Down</source>
+        <translation>Левый стик вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="28"/>
+        <source>Left Stick Left</source>
+        <translation>Левый стик влево</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="29"/>
+        <source>Left Stick Right</source>
+        <translation>Левый стик вправо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="30"/>
+        <source>Left Stick X-Axis</source>
+        <translation>Левый стик ось X</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="31"/>
+        <source>Left Stick Y-Axis</source>
+        <translation>Левый стик ось Y</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="32"/>
+        <source>Right Stick Up</source>
+        <translation>Правый стик вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="33"/>
+        <source>Right Stick Down</source>
+        <translation>Правый стик вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="34"/>
+        <source>Right Stick Left</source>
+        <translation>Правый стик влево</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="35"/>
+        <source>Right Stick Right</source>
+        <translation>Правый стик вправо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="36"/>
+        <source>Right Stick X-Axis</source>
+        <translation>Правый стик ось X</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="37"/>
+        <source>Right Stick Y-Axis</source>
+        <translation>Правый стик ось Y</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="39"/>
+        <source>Mouse 1</source>
+        <translation>Мышь 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="40"/>
+        <source>Mouse 2</source>
+        <translation>Мышь 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="41"/>
+        <source>Mouse 3</source>
+        <translation>Мышь 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="42"/>
+        <source>Mouse 4</source>
+        <translation>Мышь 4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="43"/>
+        <source>Mouse 5</source>
+        <translation>Мышь 5</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="44"/>
+        <source>Mouse 6</source>
+        <translation>Мышь 6</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="45"/>
+        <source>Mouse 7</source>
+        <translation>Мышь 7</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="46"/>
+        <source>Mouse 8</source>
+        <translation>Мышь 8</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="55"/>
+        <source>Button 1</source>
+        <translation>Кнопка 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="56"/>
+        <source>Button 2</source>
+        <translation>Кнопка 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="57"/>
+        <source>Button 3</source>
+        <translation>Кнопка 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="58"/>
+        <source>Button 4</source>
+        <translation>Кнопка 4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="59"/>
+        <source>Button 5</source>
+        <translation>Кнопка 5</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="60"/>
+        <source>Button 6</source>
+        <translation>Кнопка 6</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="61"/>
+        <source>Button 7</source>
+        <translation>Кнопка 7</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.cpp" line="62"/>
+        <source>Button 8</source>
+        <translation>Кнопка 8</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="41"/>
+        <source>You have earned a bronze trophy.
+%0</source>
+        <comment>Trophy text</comment>
+        <translation>Вы получили бронзовый трофей.
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="42"/>
+        <source>You have earned a silver trophy.
+%0</source>
+        <comment>Trophy text</comment>
+        <translation>Вы получили серебряный трофей.
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="43"/>
+        <source>You have earned a gold trophy.
+%0</source>
+        <comment>Trophy text</comment>
+        <translation>Вы получили золотой трофей.
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="44"/>
+        <source>You have earned a platinum trophy.
+%0</source>
+        <comment>Trophy text</comment>
+        <translation>Вы получили платиновый трофей.
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="45"/>
+        <source>Compiling shaders</source>
+        <translation>Компиляция шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="46"/>
+        <source>Compiling PPU Modules</source>
+        <translation>Компиляция модулей PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="47"/>
+        <source>Yes</source>
+        <comment>Message Dialog</comment>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="48"/>
+        <source>No</source>
+        <comment>Message Dialog</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="49"/>
+        <source>Back</source>
+        <comment>Message Dialog</comment>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="50"/>
+        <source>OK</source>
+        <comment>Message Dialog</comment>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="51"/>
+        <source>Save Dialog</source>
+        <comment>Save Dialog</comment>
+        <translation>Диалог сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="52"/>
+        <source>Delete Save</source>
+        <comment>Save Dialog</comment>
+        <translation>Удалить сохранение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="53"/>
+        <source>Load Save</source>
+        <comment>Save Dialog</comment>
+        <translation>Загрузить сохранение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="54"/>
+        <source>Save</source>
+        <comment>Save Dialog</comment>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="55"/>
+        <source>Enter</source>
+        <comment>OSK Dialog</comment>
+        <translation>Ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="56"/>
+        <source>Back</source>
+        <comment>OSK Dialog</comment>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="57"/>
+        <source>Space</source>
+        <comment>OSK Dialog</comment>
+        <translation>Пробел</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="58"/>
+        <source>Backspace</source>
+        <comment>OSK Dialog</comment>
+        <translation>Backspace</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="59"/>
+        <source>Shift</source>
+        <comment>OSK Dialog</comment>
+        <translation>Shift</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="60"/>
+        <source>[Enter Text]</source>
+        <comment>OSK Dialog</comment>
+        <translation>[Введите текст]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="61"/>
+        <source>[Enter Password]</source>
+        <comment>OSK Dialog</comment>
+        <translation>[Введите пароль]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="62"/>
+        <source>Select media</source>
+        <comment>Media dialog</comment>
+        <translation>Выбрать медиа</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="63"/>
+        <source>Select photo to import</source>
+        <comment>Media dialog</comment>
+        <translation>Выбрать фото для импорта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="64"/>
+        <source>No media found.</source>
+        <comment>Media dialog</comment>
+        <translation>Медиафайлы не найдены.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="65"/>
+        <source>Enter</source>
+        <comment>Enter Dialog List</comment>
+        <translation>Выбрать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="66"/>
+        <source>Back</source>
+        <comment>Cancel Dialog List</comment>
+        <translation>Назад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="67"/>
+        <source>Deny</source>
+        <comment>Deny Dialog List</comment>
+        <translation>Отклонить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="68"/>
+        <source>Pressure intensity mode of player %0 disabled</source>
+        <comment>Pressure intensity toggled off</comment>
+        <translation>Режим интенсивности нажатия игрока %0 отключён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="69"/>
+        <source>Pressure intensity mode of player %0 enabled</source>
+        <comment>Pressure intensity toggled on</comment>
+        <translation>Режим интенсивности нажатия игрока %0 включён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="70"/>
+        <source>Analog limiter of player %0 disabled</source>
+        <comment>Analog limiter toggled off</comment>
+        <translation>Ограничитель аналога игрока %0 отключён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="71"/>
+        <source>Analog limiter of player %0 enabled</source>
+        <comment>Analog limiter toggled on</comment>
+        <translation>Ограничитель аналога игрока %0 включён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="72"/>
+        <source>Mouse and keyboard are now used as emulated devices.</source>
+        <comment>Mouse and keyboard emulated</comment>
+        <translation>Мышь и клавиатура теперь используются как эмулируемые устройства.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="73"/>
+        <source>Mouse and keyboard are now used as pad.</source>
+        <comment>Mouse and keyboard pad</comment>
+        <translation>Мышь и клавиатура теперь используются как геймпад.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="74"/>
+        <source>ERROR: Game data is corrupted. The application will continue.</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Данные игры повреждены. Приложение продолжит работу.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="75"/>
+        <source>ERROR: HDD boot game is corrupted. The application will continue.</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Игра с HDD повреждена. Приложение продолжит работу.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="76"/>
+        <source>ERROR: Game data is corrupted. The application will be terminated.</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Данные игры повреждены. Приложение будет завершено.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="77"/>
+        <source>ERROR: HDD boot game is corrupted. The application will be terminated.</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Игра с HDD повреждена. Приложение будет завершено.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="78"/>
+        <source>ERROR: Not enough available space. The application will continue.
+Space needed: %0 KB</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Недостаточно места. Приложение продолжит работу.
+Требуется место: %0 КБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="79"/>
+        <source>ERROR: Not enough available space. The application will be terminated.
+Space needed: %0 KB</source>
+        <comment>Game Error</comment>
+        <translation>ОШИБКА: Недостаточно места. Приложение будет завершено.
+Требуется место: %0 КБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="80"/>
+        <source>Directory name: %0</source>
+        <comment>Game Error</comment>
+        <translation>Имя директории: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="81"/>
+        <source>There has been an error!
+
+Please remove the game data for this title.</source>
+        <comment>Game Error</comment>
+        <translation>Произошла ошибка!
+
+Пожалуйста, удалите данные игры для этого названия.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="82"/>
+        <source>There has been an error!
+
+Please reinstall the HDD boot game.</source>
+        <comment>Game Error</comment>
+        <translation>Произошла ошибка!
+
+Пожалуйста, переустановите игру с HDD.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="83"/>
+        <source>Not enough space to create HDD boot game.
+Space Needed: %0 KB</source>
+        <comment>HDD Game Check Error</comment>
+        <translation>Недостаточно места для создания игры с HDD.
+Требуется: %0 КБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="84"/>
+        <source>HDD boot game %0 is corrupt!</source>
+        <comment>HDD Game Check Error</comment>
+        <translation>Игра с HDD %0 повреждена!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="85"/>
+        <source>HDD boot game %0 could not be found!</source>
+        <comment>HDD Game Check Error</comment>
+        <translation>Игра с HDD %0 не найдена!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="86"/>
+        <source>Error: %0</source>
+        <comment>HDD Game Check Error</comment>
+        <translation>Ошибка: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="87"/>
+        <source>Not enough space to create game data.
+Space Needed: %0 KB</source>
+        <comment>Gamedata Check Error</comment>
+        <translation>Недостаточно места для создания данных игры.
+Требуется: %0 КБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="88"/>
+        <source>The game data in %0 is corrupt!</source>
+        <comment>Gamedata Check Error</comment>
+        <translation>Данные игры в %0 повреждены!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="89"/>
+        <source>The game data in %0 could not be found!</source>
+        <comment>Gamedata Check Error</comment>
+        <translation>Данные игры в %0 не найдены!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="90"/>
+        <source>Error: %0</source>
+        <comment>Gamedata Check Error</comment>
+        <translation>Ошибка: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="91"/>
+        <source>The resource is temporarily unavailable.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ресурс временно недоступен.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="92"/>
+        <source>Invalid argument or flag.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Неверный аргумент или флаг.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="93"/>
+        <source>The feature is not yet implemented.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Функция ещё не реализована.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="94"/>
+        <source>Memory allocation failed.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка выделения памяти.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="95"/>
+        <source>The resource with the specified identifier does not exist.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ресурс с указанным идентификатором не существует.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="96"/>
+        <source>The file does not exist.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файл не существует.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="97"/>
+        <source>The file is in an unrecognized format / The file is not a valid ELF file.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файл имеет нераспознанный формат / Файл не является корректным ELF.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="98"/>
+        <source>Resource deadlock is avoided.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Взаимная блокировка ресурсов предотвращена.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="99"/>
+        <source>Operation not permitted.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Операция не разрешена.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="100"/>
+        <source>The device or resource is busy.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Устройство или ресурс заняты.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="101"/>
+        <source>The operation is timed out.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Время ожидания операции истекло.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="102"/>
+        <source>The operation is aborted.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Операция прервана.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="103"/>
+        <source>Invalid memory access.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Недопустимый доступ к памяти.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="104"/>
+        <source>State of the target thread is invalid.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Состояние целевого потока недопустимо.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="105"/>
+        <source>Alignment is invalid.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Выравнивание недопустимо.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="106"/>
+        <source>Shortage of the kernel resources.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нехватка ресурсов ядра.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="107"/>
+        <source>The file is a directory.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Указанный файл является директорией.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="108"/>
+        <source>Operation cancelled.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Операция отменена.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="109"/>
+        <source>Entry already exists.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Запись уже существует.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="110"/>
+        <source>Port is already connected.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Порт уже подключён.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="111"/>
+        <source>Port is not connected.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Порт не подключён.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="112"/>
+        <source>Failure in authorizing SELF. Program authentication fail.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка авторизации SELF. Аутентификация программы не удалась.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="113"/>
+        <source>The file is not MSELF.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файл не является MSELF.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="114"/>
+        <source>System version error.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка версии системы.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="115"/>
+        <source>Fatal system error occurred while authorizing SELF. SELF auth failure.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Критическая системная ошибка при авторизации SELF.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="116"/>
+        <source>Math domain violation.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нарушение математической области.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="117"/>
+        <source>Math range violation.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нарушение математического диапазона.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="118"/>
+        <source>Illegal multi-byte sequence in input.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Недопустимая многобайтовая последовательность во вводе.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="119"/>
+        <source>File position error.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка позиции в файле.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="120"/>
+        <source>Syscall was interrupted.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Системный вызов был прерван.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="121"/>
+        <source>File too large.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файл слишком большой.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="122"/>
+        <source>Too many links.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Слишком много ссылок.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="123"/>
+        <source>File table overflow.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Переполнение таблицы файлов.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="124"/>
+        <source>No space left on device.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>На устройстве нет места.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="125"/>
+        <source>Not a TTY.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Не является TTY.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="126"/>
+        <source>Broken pipe.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Сломанный канал.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="127"/>
+        <source>Read-only filesystem.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файловая система только для чтения.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="128"/>
+        <source>Illegal seek.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Недопустимое перемещение по файлу.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="129"/>
+        <source>Arg list too long.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Список аргументов слишком длинный.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="130"/>
+        <source>Access violation.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нарушение доступа.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="131"/>
+        <source>Invalid file descriptor.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Неверный файловый дескриптор.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="132"/>
+        <source>Filesystem mounting failed.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Монтирование файловой системы не удалось.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="133"/>
+        <source>Too many files open.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Слишком много открытых файлов.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="134"/>
+        <source>No device.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Устройство не найдено.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="135"/>
+        <source>Not a directory.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Не является директорией.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="136"/>
+        <source>No such device or IO.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нет такого устройства или ввода/вывода.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="137"/>
+        <source>Cross-device link error.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка межустройственной ссылки.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="138"/>
+        <source>Bad Message.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Некорректное сообщение.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="139"/>
+        <source>In progress.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Выполняется.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="140"/>
+        <source>Message size error.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Ошибка размера сообщения.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="141"/>
+        <source>Name too long.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Имя слишком длинное.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="142"/>
+        <source>No lock.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Нет блокировки.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="143"/>
+        <source>Not empty.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Не пусто.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="144"/>
+        <source>Not supported.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Не поддерживается.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="145"/>
+        <source>File-system specific error.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Специфичная ошибка файловой системы.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="146"/>
+        <source>Overflow occurred.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Произошло переполнение.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="147"/>
+        <source>Filesystem not mounted.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Файловая система не смонтирована.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="148"/>
+        <source>Not SData.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Не является SData.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="149"/>
+        <source>Incorrect version in sys_load_param.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Некорректная версия в sys_load_param.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="150"/>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="151"/>
+        <source>Pointer is null.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Указатель равен null.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="152"/>
+        <source>An error has occurred.
+(%0)</source>
+        <comment>Error code</comment>
+        <translation>Произошла ошибка.
+(%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="153"/>
+        <source>On Screen Keyboard</source>
+        <comment>OSK Dialog</comment>
+        <translation>Экранная клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="154"/>
+        <source>The Home Menu can&apos;t be opened while the On Screen Keyboard is busy!</source>
+        <comment>OSK Dialog</comment>
+        <translation>Главное меню нельзя открыть, пока экранная клавиатура занята!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="155"/>
+        <source>Error - Save data corrupted</source>
+        <comment>Savedata Error</comment>
+        <translation>Ошибка — данные сохранения повреждены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="156"/>
+        <source>Error - Failed to save or load</source>
+        <comment>Savedata Error</comment>
+        <translation>Ошибка — не удалось сохранить или загрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="157"/>
+        <source>Error - Save data cannot be found</source>
+        <comment>Savedata Error</comment>
+        <translation>Ошибка — данные сохранения не найдены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="158"/>
+        <source>Error - Insufficient free space
+
+Space needed: %0 KB</source>
+        <comment>Savedata Error</comment>
+        <translation>Ошибка — недостаточно свободного места
+
+Требуется: %0 КБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="159"/>
+        <source>There is no saved data.</source>
+        <comment>Savedata entry info</comment>
+        <translation>Сохранённых данных нет.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="160"/>
+        <source>New Saved Data</source>
+        <comment>Savedata Dialog</comment>
+        <translation>Новые сохранённые данные</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="161"/>
+        <source>Select to create a new entry</source>
+        <comment>Savedata Dialog</comment>
+        <translation>Выберите для создания новой записи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="162"/>
+        <source>Do you want to save this data?</source>
+        <comment>Savedata Dialog</comment>
+        <translation>Вы хотите сохранить эти данные?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="163"/>
+        <source>Do you really want to delete this data?
+
+%0</source>
+        <comment>Savedata entry info</comment>
+        <translation>Вы действительно хотите удалить эти данные?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="164"/>
+        <source>Successfully removed data!
+
+%0</source>
+        <comment>Savedata entry info</comment>
+        <translation>Данные успешно удалены!
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="165"/>
+        <source>Delete this data?
+
+%0</source>
+        <comment>Savedata entry info</comment>
+        <translation>Удалить эти данные?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="166"/>
+        <source>Load this data?
+
+%0</source>
+        <comment>Savedata entry info</comment>
+        <translation>Загрузить эти данные?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="167"/>
+        <source>Do you want to overwrite the saved data?
+
+%0</source>
+        <comment>Savedata entry info</comment>
+        <translation>Вы хотите перезаписать сохранённые данные?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="168"/>
+        <source>Saving...</source>
+        <translation>Сохранение...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="169"/>
+        <source>Loading...</source>
+        <translation>Загрузка...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="170"/>
+        <source>Start [%0] on the PS Vita system.
+If you have not installed [%0], go to [Remote Play] on the PS Vita system and start [Cross-Controller] from the LiveArea™ screen.</source>
+        <comment>Cross-Controller message</comment>
+        <translation>Запустите [%0] на PS Vita.
+Если [%0] не установлен, перейдите в [Remote Play] на PS Vita и запустите [Cross-Controller] с экрана LiveArea™.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="171"/>
+        <source>If your system software version on the PS Vita system is earlier than 1.80, you must update the system software to the latest version.</source>
+        <comment>Cross-Controller firmware message</comment>
+        <translation>Если версия системного ПО PS Vita ниже 1.80, необходимо обновить его до последней версии.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="172"/>
+        <source>Select Message</source>
+        <comment>RECVMESSAGE_DIALOG</comment>
+        <translation>Выбрать сообщение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="173"/>
+        <source>Select Invite</source>
+        <comment>RECVMESSAGE_DIALOG</comment>
+        <translation>Выбрать приглашение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="174"/>
+        <source>Add Friend</source>
+        <comment>RECVMESSAGE_DIALOG</comment>
+        <translation>Добавить в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="175"/>
+        <source>From:</source>
+        <comment>RECVMESSAGE_DIALOG</comment>
+        <translation>От:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="176"/>
+        <source>Subject:</source>
+        <comment>RECVMESSAGE_DIALOG</comment>
+        <translation>Тема:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="177"/>
+        <source>Select Message To Send</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Выбрать сообщение для отправки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="178"/>
+        <source>Send Invite</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Отправить приглашение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="179"/>
+        <source>Add Friend</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Добавить в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="180"/>
+        <source>Send message to %0 ?
+
+Subject:</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Отправить сообщение %0?
+
+Тема:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="181"/>
+        <source>Send invite to %0 ?
+
+Subject:</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Отправить приглашение %0?
+
+Тема:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="182"/>
+        <source>Send friend request to %0 ?
+
+Subject:</source>
+        <comment>SENDMESSAGE_DIALOG</comment>
+        <translation>Отправить запрос в друзья %0?
+
+Тема:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="183"/>
+        <source>Recording aborted!</source>
+        <translation>Запись прервана!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="184"/>
+        <source>RPCN: No Error</source>
+        <translation>RPCN: Нет ошибки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="185"/>
+        <source>RPCN: Invalid Input (Wrong Host/Port)</source>
+        <translation>RPCN: Неверные данные (неверный хост/порт)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="186"/>
+        <source>RPCN Connection Error: WolfSSL Error</source>
+        <translation>RPCN: Ошибка подключения — ошибка WolfSSL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="187"/>
+        <source>RPCN Connection Error: Resolve Error</source>
+        <translation>RPCN: Ошибка подключения — ошибка разрешения адреса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="188"/>
+        <source>RPCN Connection Error: Failed to bind to given binding IP</source>
+        <translation>RPCN: Ошибка подключения — не удалось привязаться к указанному IP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="189"/>
+        <source>RPCN Connection Error</source>
+        <translation>RPCN: Ошибка подключения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="190"/>
+        <source>RPCN Login Error: Identification Error</source>
+        <translation>RPCN: Ошибка входа — ошибка идентификации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="191"/>
+        <source>RPCN Login Error: User Already Logged In</source>
+        <translation>RPCN: Ошибка входа — пользователь уже в сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="192"/>
+        <source>RPCN Login Error: Invalid Username</source>
+        <translation>RPCN: Ошибка входа — неверное имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="193"/>
+        <source>RPCN Login Error: Invalid Password</source>
+        <translation>RPCN: Ошибка входа — неверный пароль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="194"/>
+        <source>RPCN Login Error: Invalid Token</source>
+        <translation>RPCN: Ошибка входа — неверный токен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="195"/>
+        <source>RPCN Misc Error: Protocol Version Error (outdated RPCS3?)</source>
+        <translation>RPCN: Ошибка версии протокола (устаревший RPCS3?)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="196"/>
+        <source>RPCN: Unknown Error</source>
+        <translation>RPCN: Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="197"/>
+        <source>Successfully logged on RPCN!</source>
+        <translation>Успешный вход в RPCN!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="198"/>
+        <source>RPCN: Received friend request: %0</source>
+        <comment>RCPN Friends</comment>
+        <translation>RPCN: Получен запрос в друзья: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="199"/>
+        <source>RPCN: Friend added: %0</source>
+        <comment>RCPN Friends</comment>
+        <translation>RPCN: Друг добавлен: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="200"/>
+        <source>RPCN: Friend removed: %0</source>
+        <comment>RCPN Friends</comment>
+        <translation>RPCN: Друг удалён: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="201"/>
+        <source>RPCN: %0 logged in</source>
+        <comment>RCPN Friends</comment>
+        <translation>RPCN: %0 вошёл в сеть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="202"/>
+        <source>RPCN: %0 logged out</source>
+        <comment>RCPN Friends</comment>
+        <translation>RPCN: %0 вышел из сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="203"/>
+        <source>Home Menu</source>
+        <translation>Главное меню</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="204"/>
+        <source>Exit Game</source>
+        <translation>Выйти из игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="205"/>
+        <source>Resume Game</source>
+        <translation>Продолжить игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="206"/>
+        <source>Friends</source>
+        <translation>Друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="207"/>
+        <source>Pending Friend Requests</source>
+        <translation>Входящие запросы в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="208"/>
+        <source>Blocked Users</source>
+        <translation>Заблокированные пользователи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="209"/>
+        <source>Online</source>
+        <translation>В сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="210"/>
+        <source>Offline</source>
+        <translation>Не в сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="211"/>
+        <source>Blocked</source>
+        <translation>Заблокирован</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="212"/>
+        <source>You sent a friend request</source>
+        <translation>Вы отправили запрос в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="213"/>
+        <source>Sent you a friend request</source>
+        <translation>Отправил вам запрос в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="214"/>
+        <source>Block this user?
+
+%0</source>
+        <translation>Заблокировать этого пользователя?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="215"/>
+        <source>Unblock this user?
+
+%0</source>
+        <translation>Разблокировать этого пользователя?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="216"/>
+        <source>Remove this user?
+
+%0</source>
+        <translation>Удалить этого пользователя?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="217"/>
+        <source>Accept Request?
+
+%0</source>
+        <translation>Принять запрос?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="218"/>
+        <source>Cancel Request?
+
+%0</source>
+        <translation>Отменить запрос?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="219"/>
+        <source>Reject Request?
+
+%0</source>
+        <translation>Отклонить запрос?
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="220"/>
+        <source>Reject Request</source>
+        <translation>Отклонить запрос</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="221"/>
+        <source>Next list</source>
+        <translation>Следующий список</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="222"/>
+        <source>Restart Game</source>
+        <translation>Перезапустить игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="223"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="224"/>
+        <source>Save custom configuration?</source>
+        <translation>Сохранить пользовательскую конфигурацию?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="225"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="226"/>
+        <source>Discard the current settings&apos; changes?</source>
+        <translation>Отменить текущие изменения настроек?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="227"/>
+        <source>Discard</source>
+        <translation>Отменить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="228"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="229"/>
+        <source>Master Volume</source>
+        <comment>Audio</comment>
+        <translation>Основная громкость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="230"/>
+        <source>Audio Backend</source>
+        <comment>Audio</comment>
+        <translation>Аудиобэкенд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="231"/>
+        <source>Enable Buffering</source>
+        <comment>Audio</comment>
+        <translation>Включить буферизацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="232"/>
+        <source>Desired Audio Buffer Duration</source>
+        <comment>Audio</comment>
+        <translation>Желаемая длительность аудиобуфера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="233"/>
+        <source>Enable Time Stretching</source>
+        <comment>Audio</comment>
+        <translation>Включить растяжение по времени</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="234"/>
+        <source>Time Stretching Threshold</source>
+        <comment>Audio</comment>
+        <translation>Порог растяжения по времени</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="235"/>
+        <source>Video</source>
+        <translation>Видео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="236"/>
+        <source>Frame Limit</source>
+        <comment>Video</comment>
+        <translation>Ограничение FPS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="237"/>
+        <source>Anisotropic Filter Override</source>
+        <comment>Video</comment>
+        <translation>Переопределение анизотропной фильтрации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="238"/>
+        <source>Output Scaling</source>
+        <comment>Video</comment>
+        <translation>Масштабирование вывода</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="239"/>
+        <source>FidelityFX CAS Sharpening Intensity</source>
+        <comment>Video</comment>
+        <translation>Интенсивность заточки FidelityFX CAS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="240"/>
+        <source>Stretch To Display Area</source>
+        <comment>Video</comment>
+        <translation>Растянуть на область отображения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="241"/>
+        <source>Stereo Mode</source>
+        <comment>Video</comment>
+        <translation>Стерео режим</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="242"/>
+        <source>Input</source>
+        <translation>Ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="243"/>
+        <source>Background Input Enabled</source>
+        <comment>Input</comment>
+        <translation>Фоновый ввод включён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="244"/>
+        <source>Keep Pads Connected</source>
+        <comment>Input</comment>
+        <translation>Держать геймпады подключёнными</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="245"/>
+        <source>Show PS Move Cursor</source>
+        <comment>Input</comment>
+        <translation>Показывать курсор PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="246"/>
+        <source>Camera Flip</source>
+        <comment>Input</comment>
+        <translation>Переворот камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="247"/>
+        <source>Pad Handler Mode</source>
+        <comment>Input</comment>
+        <translation>Режим обработчика геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="248"/>
+        <source>Pad Handler Sleep</source>
+        <comment>Input</comment>
+        <translation>Сон обработчика геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="249"/>
+        <source>Fake PS Move Rotation Cone (Horizontal)</source>
+        <comment>Input</comment>
+        <translation>Симуляция вращения PS Move (горизонталь)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="250"/>
+        <source>Fake PS Move Rotation Cone (Vertical)</source>
+        <comment>Input</comment>
+        <translation>Симуляция вращения PS Move (вертикаль)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="251"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="252"/>
+        <source>Preferred SPU Threads</source>
+        <comment>Advanced</comment>
+        <translation>Предпочтительное число потоков SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="253"/>
+        <source>Max Power Saving CPU-Preemptions</source>
+        <comment>Advanced</comment>
+        <translation>Макс. вытеснений CPU для экономии энергии</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="254"/>
+        <source>Accurate RSX reservation access</source>
+        <comment>Advanced</comment>
+        <translation>Точный доступ к резервированию RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="255"/>
+        <source>Sleep Timers Accuracy</source>
+        <comment>Advanced</comment>
+        <translation>Точность таймеров сна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="256"/>
+        <source>Max SPURS Threads</source>
+        <comment>Advanced</comment>
+        <translation>Максимальное число потоков SPURS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="257"/>
+        <source>Driver Wake-Up Delay</source>
+        <comment>Advanced</comment>
+        <translation>Задержка пробуждения драйвера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="258"/>
+        <source>VBlank Frequency</source>
+        <comment>Advanced</comment>
+        <translation>Частота VBlank</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="259"/>
+        <source>VBlank NTSC Fixup</source>
+        <comment>Advanced</comment>
+        <translation>Исправление VBlank NTSC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="260"/>
+        <source>Overlays</source>
+        <translation>Оверлеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="261"/>
+        <source>Show Trophy Popups</source>
+        <comment>Overlays</comment>
+        <translation>Показывать уведомления о трофеях</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="262"/>
+        <source>Show RPCN Popups</source>
+        <comment>Overlays</comment>
+        <translation>Показывать уведомления RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="263"/>
+        <source>Show Shader Compilation Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку компиляции шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="264"/>
+        <source>Show PPU Compilation Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку компиляции PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="265"/>
+        <source>Show Autosave/Autoload Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку автосохранения/автозагрузки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="266"/>
+        <source>Show Pressure Intensity Toggle Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку переключения интенсивности нажатия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="267"/>
+        <source>Show Analog Limiter Toggle Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку переключения ограничителя аналога</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="268"/>
+        <source>Show Mouse And Keyboard Toggle Hint</source>
+        <comment>Overlays</comment>
+        <translation>Показывать подсказку переключения мыши и клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="269"/>
+        <source>Record With Overlays</source>
+        <comment>Overlays</comment>
+        <translation>Записывать с оверлеями</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="270"/>
+        <source>Performance Overlay</source>
+        <translation>Оверлей производительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="271"/>
+        <source>Enable Performance Overlay</source>
+        <comment>Performance Overlay</comment>
+        <translation>Включить оверлей производительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="272"/>
+        <source>Enable Framerate Graph</source>
+        <comment>Performance Overlay</comment>
+        <translation>Включить график FPS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="273"/>
+        <source>Enable Frametime Graph</source>
+        <comment>Performance Overlay</comment>
+        <translation>Включить график времени кадра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="274"/>
+        <source>Detail level</source>
+        <comment>Performance Overlay</comment>
+        <translation>Уровень детализации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="275"/>
+        <source>Framerate Graph Detail Level</source>
+        <comment>Performance Overlay</comment>
+        <translation>Уровень детализации графика FPS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="276"/>
+        <source>Frametime Graph Detail Level</source>
+        <comment>Performance Overlay</comment>
+        <translation>Уровень детализации графика времени кадра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="277"/>
+        <source>Framerate Datapoints</source>
+        <comment>Performance Overlay</comment>
+        <translation>Точки данных FPS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="278"/>
+        <source>Frametime Datapoints</source>
+        <comment>Performance Overlay</comment>
+        <translation>Точки данных времени кадра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="279"/>
+        <source>Metrics Update Interval</source>
+        <comment>Performance Overlay</comment>
+        <translation>Интервал обновления метрик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="280"/>
+        <source>Position</source>
+        <comment>Performance Overlay</comment>
+        <translation>Позиция</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="281"/>
+        <source>Center Horizontally</source>
+        <comment>Performance Overlay</comment>
+        <translation>Центрировать по горизонтали</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="282"/>
+        <source>Center Vertically</source>
+        <comment>Performance Overlay</comment>
+        <translation>Центрировать по вертикали</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="283"/>
+        <source>Horizontal Margin</source>
+        <comment>Performance Overlay</comment>
+        <translation>Горизонтальный отступ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="284"/>
+        <source>Vertical Margin</source>
+        <comment>Performance Overlay</comment>
+        <translation>Вертикальный отступ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="285"/>
+        <source>Font Size</source>
+        <comment>Performance Overlay</comment>
+        <translation>Размер шрифта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="286"/>
+        <source>Opacity</source>
+        <comment>Performance Overlay</comment>
+        <translation>Прозрачность</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="287"/>
+        <source>Debug</source>
+        <translation>Отладка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="288"/>
+        <source>Debug Overlay</source>
+        <comment>Debug</comment>
+        <translation>Отладочный оверлей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="289"/>
+        <source>Input Debug Overlay</source>
+        <comment>Debug</comment>
+        <translation>Отладочный оверлей ввода</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="290"/>
+        <source>Mouse Debug Overlay</source>
+        <comment>Debug</comment>
+        <translation>Отладочный оверлей мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="291"/>
+        <source>Disable Video Output</source>
+        <comment>Debug</comment>
+        <translation>Отключить видеовывод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="292"/>
+        <source>Texture LOD Bias Addend</source>
+        <comment>Debug</comment>
+        <translation>Добавка смещения LOD текстур</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="293"/>
+        <source>Take Screenshot</source>
+        <translation>Сделать снимок экрана</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="294"/>
+        <source>SaveState</source>
+        <translation>Состояние сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="295"/>
+        <source>Save Emulation State</source>
+        <translation>Сохранить состояние эмуляции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="296"/>
+        <source>Save Emulation State And Exit</source>
+        <translation>Сохранить состояние эмуляции и выйти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="297"/>
+        <source>Reload Last Emulation State</source>
+        <translation>Загрузить последнее состояние эмуляции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="298"/>
+        <source>Reload Second-To-Last Emulation State</source>
+        <translation>Загрузить предпоследнее состояние эмуляции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="299"/>
+        <source>Reload Third-To-Last Emulation State</source>
+        <translation>Загрузить третье с конца состояние эмуляции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="300"/>
+        <source>Reload Fourth-To-Last Emulation State</source>
+        <translation>Загрузить четвёртое с конца состояние эмуляции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="301"/>
+        <source>Toggle Fullscreen</source>
+        <translation>Переключить полноэкранный режим</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="302"/>
+        <source>Start/Stop Recording</source>
+        <translation>Начать/остановить запись</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="303"/>
+        <source>Trophies</source>
+        <translation>Трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="304"/>
+        <source>Trophy Progress: %0</source>
+        <translation>Прогресс трофеев: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="305"/>
+        <source>Locked trophy: %0</source>
+        <translation>Заблокированный трофей: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="306"/>
+        <source>Hidden trophy</source>
+        <translation>Скрытый трофей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="307"/>
+        <source>This trophy is hidden</source>
+        <translation>Этот трофей скрыт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="308"/>
+        <source>Show hidden trophies</source>
+        <translation>Показать скрытые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="309"/>
+        <source>Hide hidden trophies</source>
+        <translation>Скрыть скрытые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="310"/>
+        <source>Platinum relevant</source>
+        <translation>Связан с платиной</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="311"/>
+        <source>Bronze</source>
+        <comment>Trophy type</comment>
+        <translation>Бронза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="312"/>
+        <source>Silver</source>
+        <comment>Trophy type</comment>
+        <translation>Серебро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="313"/>
+        <source>Gold</source>
+        <comment>Trophy type</comment>
+        <translation>Золото</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="314"/>
+        <source>Platinum</source>
+        <comment>Trophy type</comment>
+        <translation>Платина</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="315"/>
+        <source>Audio muted</source>
+        <comment>Audio</comment>
+        <translation>Аудио отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="316"/>
+        <source>Audio unmuted</source>
+        <comment>Audio</comment>
+        <translation>Аудио включено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="317"/>
+        <source>Volume changed to %0</source>
+        <comment>Audio</comment>
+        <translation>Громкость изменена до %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="318"/>
+        <source>Progress:</source>
+        <translation>Прогресс:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="319"/>
+        <source>Progress: analyzing...</source>
+        <translation>Прогресс: анализ...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="320"/>
+        <source>remaining</source>
+        <translation>осталось</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="321"/>
+        <source>done</source>
+        <translation>выполнено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="322"/>
+        <source>file</source>
+        <translation>файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="323"/>
+        <source>module</source>
+        <translation>модуль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="324"/>
+        <source>of</source>
+        <translation>из</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="325"/>
+        <source>Please wait</source>
+        <translation>Подождите</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="326"/>
+        <source>Stopping. Please wait...</source>
+        <translation>Остановка. Подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="327"/>
+        <source>Creating savestate. Please wait...</source>
+        <translation>Создание сохранения. Подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="328"/>
+        <source>Scanning PPU Executable...</source>
+        <translation>Сканирование исполняемого файла PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="329"/>
+        <source>Analyzing PPU Executable...</source>
+        <translation>Анализ исполняемого файла PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="330"/>
+        <source>Scanning PPU Modules...</source>
+        <translation>Сканирование модулей PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="331"/>
+        <source>Loading PPU Modules...</source>
+        <translation>Загрузка модулей PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="332"/>
+        <source>Compiling PPU Modules...</source>
+        <translation>Компиляция модулей PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="333"/>
+        <source>Linking PPU Modules...</source>
+        <translation>Связывание модулей PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="334"/>
+        <source>Applying PPU Code...</source>
+        <translation>Применение кода PPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="335"/>
+        <source>Building SPU Cache...</source>
+        <translation>Построение кэша SPU...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="336"/>
+        <source>Press and hold the START button to resume</source>
+        <translation>Нажмите и удерживайте кнопку START для продолжения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="337"/>
+        <source>Resuming...!</source>
+        <translation>Возобновление...!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="338"/>
+        <source>The PS3 application has likely crashed, you can close it.</source>
+        <translation>Приложение PS3 скорее всего вылетело, вы можете закрыть его.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="339"/>
+        <source>SaveState failed: Game saving is in progress, wait until finished.</source>
+        <translation>Сохранение не удалось: идёт сохранение игры, дождитесь завершения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="340"/>
+        <source>SaveState failed: VDEC-based video/cutscenes are in order, wait for them to end or enable libvdec.sprx.</source>
+        <translation>Сохранение не удалось: воспроизводится видео/катсцена на VDEC, дождитесь окончания или включите libvdec.sprx.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="341"/>
+        <source>SaveState failed: Failed to lock SPU state, enabling SPU-Compatible mode may fix it.</source>
+        <translation>Сохранение не удалось: не удалось заблокировать состояние SPU, попробуйте включить SPU-совместимый режим.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="342"/>
+        <source>SaveState failed: Failed to lock SPU state, using SPU ASMJIT will fix it.</source>
+        <translation>Сохранение не удалось: не удалось заблокировать состояние SPU, использование SPU ASMJIT исправит это.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="343"/>
+        <source>Invalid</source>
+        <translation>Недопустимо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/localized_emu.h" line="344"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+</context>
+<context>
+    <name>log_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="114"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="155"/>
+        <source>Log</source>
+        <translation>Журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="140"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="318"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="324"/>
+        <source>Channel %0</source>
+        <translation>Канал %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="144"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="307"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="313"/>
+        <source>All user channels</source>
+        <translation>Все пользовательские каналы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="156"/>
+        <source>TTY</source>
+        <translation>TTY</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="235"/>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="243"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="250"/>
+        <source>Go-To on Debugger</source>
+        <translation>Перейти в отладчике</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="257"/>
+        <source>Show in Memory Viewer</source>
+        <translation>Показать в просмотрщике памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="265"/>
+        <source>Invalid Hex</source>
+        <translation>Недопустимое шестнадцатеричное значение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="265"/>
+        <source>”%0” is not a valid 32-bit hex value.</source>
+        <translation>”%0” не является допустимым 32-битным шестнадцатеричным значением.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="272"/>
+        <source>Show Thread on Debugger</source>
+        <translation>Показать поток в отладчике</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="279"/>
+        <source>Stack Mode (TTY)</source>
+        <translation>Режим стека (TTY)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="287"/>
+        <source>ANSI Code (TTY)</source>
+        <translation>ANSI-коды (TTY)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="330"/>
+        <source>Nothing</source>
+        <translation>Ничего</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="332"/>
+        <source>Fatal</source>
+        <translation>Критическая ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="333"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="334"/>
+        <source>Todo</source>
+        <translation>TODO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="335"/>
+        <source>Success</source>
+        <translation>Успешно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="336"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="337"/>
+        <source>Notice</source>
+        <translation>Уведомление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="338"/>
+        <source>Trace</source>
+        <translation>Трассировка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="340"/>
+        <source>Stack Mode (Log)</source>
+        <translation>Режим стека (журнал)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="348"/>
+        <source>Stack Cell Errors</source>
+        <translation>Ошибки ячеек стека</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="356"/>
+        <source>Show Thread Prefix</source>
+        <translation>Показывать префикс потока</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="364"/>
+        <source>Print Log/TTY while hidden</source>
+        <translation>Выводить журнал/TTY в скрытом режиме</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="376"/>
+        <source>Enable TTY</source>
+        <translation>Включить TTY</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="406"/>
+        <source>Jump to the selected hexadecimal address from the log text on the debugger.</source>
+        <translation>Перейти к выбранному шестнадцатеричному адресу из текста журнала в отладчике.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="407"/>
+        <source>Show the thread that corresponds to the thread ID from the log text on the debugger.</source>
+        <translation>Показать поток, соответствующий ID потока из текста журнала в отладчике.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="408"/>
+        <source>Jump to the selected hexadecimal address from the log text on the memory viewer.</source>
+        <translation>Перейти к выбранному шестнадцатеричному адресу из текста журнала в просмотрщике памяти.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="432"/>
+        <source>Jump to the selected hexadecimal address from the TTY text on the debugger.</source>
+        <translation>Перейти к выбранному шестнадцатеричному адресу из текста TTY в отладчике.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_frame.cpp" line="433"/>
+        <source>Jump to the selected hexadecimal address from the TTY text on the memory viewer.</source>
+        <translation>Перейти к выбранному шестнадцатеричному адресу из текста TTY в просмотрщике памяти.</translation>
+    </message>
+</context>
+<context>
+    <name>log_level_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="17"/>
+        <source>Configure minimum log levels</source>
+        <translation>Настройка минимальных уровней журнала</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="30"/>
+        <source>Always</source>
+        <translation>Всегда</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="31"/>
+        <source>Fatal</source>
+        <translation>Критическая ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="32"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="33"/>
+        <source>Todo</source>
+        <translation>TODO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="34"/>
+        <source>Success</source>
+        <translation>Успешно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="35"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="36"/>
+        <source>Notice</source>
+        <translation>Уведомление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="37"/>
+        <source>Trace</source>
+        <translation>Трассировка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="49"/>
+        <source>Channel</source>
+        <translation>Канал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="49"/>
+        <source>Level</source>
+        <translation>Уровень</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_level_dialog.cpp" line="82"/>
+        <source>Filter channels</source>
+        <translation>Фильтр каналов</translation>
+    </message>
+</context>
+<context>
+    <name>log_viewer</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="69"/>
+        <source> | Filter &apos;%0&apos;</source>
+        <translation> | Фильтр &apos;%0&apos;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="74"/>
+        <source> | Exclude &apos;%0&apos;</source>
+        <translation> | Исключить &apos;%0&apos;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="77"/>
+        <source>Log Viewer%0</source>
+        <translation>Просмотрщик журнала%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="83"/>
+        <source>&amp;Clear</source>
+        <translation>&amp;Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="84"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Копировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="85"/>
+        <source>&amp;Open log file</source>
+        <translation>&amp;Открыть файл журнала</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="86"/>
+        <source>&amp;Save filtered log</source>
+        <translation>&amp;Сохранить отфильтрованный журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="87"/>
+        <source>&amp;Filter log%0</source>
+        <translation>&amp;Фильтр журнала%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="88"/>
+        <source>&amp;Exclude%0</source>
+        <translation>&amp;Исключить%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="89"/>
+        <source>&amp;Check config</source>
+        <translation>&amp;Проверить конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="91"/>
+        <source>&amp;Show Timestamps</source>
+        <translation>&amp;Показывать временные метки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="95"/>
+        <source>&amp;Show Threads</source>
+        <translation>&amp;Показывать потоки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="99"/>
+        <source>&amp;Last actions only</source>
+        <translation>&amp;Только последние действия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="104"/>
+        <source>Fatal</source>
+        <translation>Критическая ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="105"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="106"/>
+        <source>Todo</source>
+        <translation>TODO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="107"/>
+        <source>Success</source>
+        <translation>Успешно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="108"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="109"/>
+        <source>Notice</source>
+        <translation>Уведомление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="110"/>
+        <source>Trace</source>
+        <translation>Трассировка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="164"/>
+        <source>Select log file</source>
+        <translation>Выбрать файл журнала</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="164"/>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="173"/>
+        <source>Log files (*.log *.gz);;All files (*.*)</source>
+        <translation>Файлы журналов (*.log *.gz);;Все файлы (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="173"/>
+        <source>Save to file</source>
+        <translation>Сохранить в файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="211"/>
+        <source>Filter log</source>
+        <translation>Фильтровать журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="211"/>
+        <source>Enter text</source>
+        <translation>Введите текст</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="221"/>
+        <source>Exclude</source>
+        <translation>Исключить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="221"/>
+        <source>Enter text (comma separated)</source>
+        <translation>Введите текст (через запятую)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="274"/>
+        <source>Loading file...</source>
+        <translation>Загрузка файла...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="307"/>
+        <source>Failed to open &apos;%0&apos;</source>
+        <translation>Не удалось открыть &apos;%0&apos;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="320"/>
+        <source>Pasting...</source>
+        <translation>Вставка...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="336"/>
+        <source>Filtering...</source>
+        <translation>Фильтрация...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="446"/>
+        <source>Ooops!</source>
+        <translation>Упс!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/log_viewer.cpp" line="446"/>
+        <source>Cannot find any game boot!</source>
+        <translation>Не удалось найти ни одной загрузки игры!</translation>
+    </message>
+</context>
+<context>
+    <name>main_window</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="26"/>
+        <source>RPCS3</source>
+        <translation>RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="75"/>
+        <source>Search...</source>
+        <translation>Поиск...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="151"/>
+        <source>File</source>
+        <translation>Файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="158"/>
+        <source>Boot (S)Elf</source>
+        <translation>Запустить (S)ELF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="168"/>
+        <source>Boot Recent</source>
+        <translation>Недавние запуски</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="179"/>
+        <source>All Titles</source>
+        <translation>Все игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="196"/>
+        <source>Firmware</source>
+        <translation>Прошивка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="203"/>
+        <source>Boot Recent Savestate</source>
+        <translation>Недавние сохранения состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="233"/>
+        <source>Emulation</source>
+        <translation>Эмуляция</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="244"/>
+        <source>Configuration</source>
+        <translation>Конфигурация</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="248"/>
+        <source>Devices</source>
+        <translation>Устройства</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="252"/>
+        <source>Mice</source>
+        <translation>Мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="264"/>
+        <source>Emulated Devices</source>
+        <translation>Эмулируемые устройства</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="298"/>
+        <source>Manage</source>
+        <translation>Управление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="302"/>
+        <source>Network Services</source>
+        <translation>Сетевые сервисы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="310"/>
+        <source>Portals and Gates</source>
+        <translation>Порталы и шлюзы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="335"/>
+        <source>Utilities</source>
+        <translation>Утилиты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="361"/>
+        <source>View</source>
+        <translation>Вид</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="365"/>
+        <source>Game List Icons</source>
+        <translation>Иконки списка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="378"/>
+        <source>Game List View</source>
+        <translation>Вид списка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="385"/>
+        <source>Game List in Grid Mode</source>
+        <translation>Список игр в режиме сетки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="391"/>
+        <source>Game Categories</source>
+        <translation>Категории игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="423"/>
+        <source>Help</source>
+        <translation>Справка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="427"/>
+        <source>Language</source>
+        <translation>Язык</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="442"/>
+        <source>Update Available!</source>
+        <translation>Доступно обновление!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="466"/>
+        <source>Show tool bar</source>
+        <translation>Показывать панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="505"/>
+        <source>Boot SELF/ELF</source>
+        <translation>Запустить SELF/ELF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="510"/>
+        <source>Boot Test</source>
+        <translation>Тестовый запуск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="515"/>
+        <source>Boot Game</source>
+        <translation>Запустить игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="520"/>
+        <source>Boot Savestate</source>
+        <translation>Запустить из сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="525"/>
+        <source>Install Packages/Raps/Edats</source>
+        <translation>Установить пакеты/RAP/EDAT</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="528"/>
+        <source>Install application from a .pkg file</source>
+        <translation>Установить приложение из .pkg файла</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="533"/>
+        <source>Install Firmware</source>
+        <translation>Установить прошивку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="536"/>
+        <source>Install firmware from PS3UPDAT.PUP</source>
+        <translation>Установить прошивку из PS3UPDAT.PUP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="548"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1895"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1916"/>
+        <source>Pause</source>
+        <translation>Пауза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="551"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1021"/>
+        <source>Start emulation</source>
+        <translation>Запустить эмуляцию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="563"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1030"/>
+        <source>Stop</source>
+        <translation>Стоп</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="566"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1033"/>
+        <source>Stop emulation</source>
+        <translation>Остановить эмуляцию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="574"/>
+        <source>Send Open System Menu CMD</source>
+        <translation>Отправить команду открытия системного меню</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="579"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="582"/>
+        <source>Configure CPU</source>
+        <translation>Настройка CPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="587"/>
+        <source>GPU</source>
+        <translation>GPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="590"/>
+        <source>Configure graphics</source>
+        <translation>Настройка графики</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="595"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="598"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1066"/>
+        <source>Pads</source>
+        <translation>Геймпады</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="601"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1069"/>
+        <source>Configure controls</source>
+        <translation>Настройка управления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="606"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="609"/>
+        <source>Configure audio</source>
+        <translation>Настройка звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="614"/>
+        <source>Input/Output</source>
+        <translation>Ввод/вывод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="617"/>
+        <source>Configure Input/Output</source>
+        <translation>Настройка ввода/вывода</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="622"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="625"/>
+        <source>Configure system</source>
+        <translation>Настройка системы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="630"/>
+        <source>Network</source>
+        <translation>Сеть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="633"/>
+        <source>Configure Network settings</source>
+        <translation>Настройка параметров сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="638"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="641"/>
+        <source>Configure advanced emulator settings</source>
+        <translation>Настройка расширенных параметров эмулятора</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="646"/>
+        <source>Emulator</source>
+        <translation>Эмулятор</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="649"/>
+        <source>Configure Emulator settings</source>
+        <translation>Настройка параметров эмулятора</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="654"/>
+        <source>GUI</source>
+        <translation>GUI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="657"/>
+        <source>Configure GUI settings</source>
+        <translation>Настройка GUI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="665"/>
+        <source>Auto Pause</source>
+        <translation>Автопауза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="668"/>
+        <source>Configure Auto Pause</source>
+        <translation>Настройка автопаузы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="673"/>
+        <source>Exit and Save Log</source>
+        <translation>Выйти и сохранить журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="676"/>
+        <source>Exit RPCS3, move the log file to a custom location</source>
+        <translation>Выйти из RPCS3, переместив журнал в пользовательское место</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="679"/>
+        <source>Exit the application and save the log to a user-defined location</source>
+        <translation>Выйти из приложения и сохранить журнал в указанное место</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="684"/>
+        <source>Exit</source>
+        <translation>Выход</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="687"/>
+        <source>Exit RPCS3</source>
+        <translation>Выйти из RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="690"/>
+        <source>Exit the application.</source>
+        <translation>Выйти из приложения.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="698"/>
+        <source>Save Data</source>
+        <translation>Данные сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="701"/>
+        <source>Manage save data</source>
+        <translation>Управление данными сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="709"/>
+        <source>Trophies</source>
+        <translation>Трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="712"/>
+        <source>Manage trophies</source>
+        <translation>Управление трофеями</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="717"/>
+        <source>User Accounts</source>
+        <translation>Учётные записи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="720"/>
+        <source>Manage user accounts</source>
+        <translation>Управление учётными записями</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="725"/>
+        <source>Cg Disasm</source>
+        <translation>Cg Disasm</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="733"/>
+        <source>Kernel Explorer</source>
+        <translation>Проводник ядра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="741"/>
+        <source>Memory Viewer</source>
+        <translation>Просмотрщик памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="749"/>
+        <source>RSX Debugger</source>
+        <translation>Отладчик RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="754"/>
+        <source>Decrypt PS3 Binaries</source>
+        <translation>Дешифровать бинарные файлы PS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="759"/>
+        <source>Extract MSELF</source>
+        <translation>Извлечь MSELF</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="764"/>
+        <source>Extract PUP</source>
+        <translation>Извлечь PUP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="769"/>
+        <source>Extract Encrypted TAR</source>
+        <translation>Извлечь зашифрованный TAR</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="772"/>
+        <source>Extract files from special .tar files inside PS3UPDAT.PUP</source>
+        <translation>Извлечь файлы из специальных .tar файлов в PS3UPDAT.PUP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="780"/>
+        <source>Show Debugger</source>
+        <translation>Показать отладчик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="788"/>
+        <source>Show Log/TTY</source>
+        <translation>Показать журнал/TTY</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="793"/>
+        <source>Support Us</source>
+        <translation>Поддержать нас</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="796"/>
+        <source>To ensure continued improvements of RPCS3, become a part of our Patreon group!</source>
+        <translation>Чтобы обеспечить дальнейшее развитие RPCS3, вступите в нашу группу на Patreon!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="801"/>
+        <source>About RPCS3</source>
+        <translation>О программе RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="806"/>
+        <source>About Qt</source>
+        <translation>О Qt</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="814"/>
+        <source>Show Game List</source>
+        <translation>Показать список игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="822"/>
+        <source>Show Tool Bar</source>
+        <translation>Показать панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="830"/>
+        <source>Show Game Compatibility</source>
+        <translation>Показывать совместимость игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="835"/>
+        <source>Refresh Game List</source>
+        <translation>Обновить список игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="843"/>
+        <source>RAP Files</source>
+        <translation>RAP-файлы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="848"/>
+        <source>Check for Updates</source>
+        <translation>Проверить обновления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="853"/>
+        <source>View Welcome Dialog</source>
+        <translation>Показать приветственное окно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="858"/>
+        <source>Virtual File System</source>
+        <translation>Виртуальная файловая система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="863"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1478"/>
+        <source>List Clear</source>
+        <translation>Очистить список</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="871"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1486"/>
+        <source>List Freeze</source>
+        <translation>Заморозить список</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="879"/>
+        <source>Tiny</source>
+        <translation>Крошечный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="890"/>
+        <source>Small</source>
+        <translation>Маленький</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="898"/>
+        <source>Medium</source>
+        <translation>Средний</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="906"/>
+        <source>Large</source>
+        <translation>Большой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="917"/>
+        <source>List Mode</source>
+        <translation>Режим списка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="925"/>
+        <source>Grid Mode</source>
+        <translation>Режим сетки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="937"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1965"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3585"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3608"/>
+        <source>Restart</source>
+        <translation>Перезапустить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="945"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3348"/>
+        <source>HDD Games</source>
+        <translation>Игры на HDD</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="953"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3349"/>
+        <source>Disc Games</source>
+        <translation>Дисковые игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="961"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3350"/>
+        <source>PS1 Games</source>
+        <translation>Игры PS1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="969"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3351"/>
+        <source>PS2 Games</source>
+        <translation>Игры PS2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="977"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3352"/>
+        <source>PSP Games</source>
+        <translation>Игры PSP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="985"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3353"/>
+        <source>Home</source>
+        <translation>Главная</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="993"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3354"/>
+        <source>Audio/Video</source>
+        <translation>Аудио/видео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1001"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3355"/>
+        <source>Game Data</source>
+        <translation>Данные игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1009"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3357"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1018"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1042"/>
+        <source>Config</source>
+        <translation>Конфигурация</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1045"/>
+        <source>Configure the emulator</source>
+        <translation>Настройка эмулятора</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1054"/>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1295"/>
+        <source>RPCN</source>
+        <translation>RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1057"/>
+        <source>Configure RPCN settings</source>
+        <translation>Настройка RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1078"/>
+        <source>FullScr</source>
+        <translation>Полный экран</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1081"/>
+        <source>Toggle fullscreen</source>
+        <translation>Переключить полный экран</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1090"/>
+        <source>List</source>
+        <translation>Список</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1093"/>
+        <source>Switch to list mode</source>
+        <translation>Переключиться в режим списка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1102"/>
+        <source>Grid</source>
+        <translation>Сетка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1105"/>
+        <source>Switch to grid mode</source>
+        <translation>Переключиться в режим сетки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1114"/>
+        <source>Refresh</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1117"/>
+        <source>Refresh gamelist</source>
+        <translation>Обновить список игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1126"/>
+        <source>Open</source>
+        <translation>Открыть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1129"/>
+        <source>Boot a game</source>
+        <translation>Запустить игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1137"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3358"/>
+        <source>Other</source>
+        <translation>Другое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1145"/>
+        <source>Show Hidden Entries</source>
+        <translation>Показать скрытые записи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1150"/>
+        <source>Open RSX Capture</source>
+        <translation>Открыть RSX Capture</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1155"/>
+        <source>Add Games</source>
+        <translation>Добавить игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1163"/>
+        <source>Show Title Bars</source>
+        <translation>Показывать заголовки окон</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1168"/>
+        <source>Create LLVM Caches</source>
+        <translation>Создать кэши LLVM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1173"/>
+        <source>Remove Custom Configurations</source>
+        <translation>Удалить пользовательские конфигурации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1178"/>
+        <source>Remove Custom Gamepad Configurations</source>
+        <translation>Удалить конфигурации геймпадов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1183"/>
+        <source>Remove Shader Caches</source>
+        <translation>Удалить кэши шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1188"/>
+        <source>Remove PPU Caches</source>
+        <translation>Удалить кэши PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1193"/>
+        <source>Remove SPU Caches</source>
+        <translation>Удалить кэши SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1198"/>
+        <source>Remove HDD1 Caches</source>
+        <translation>Удалить кэши HDD1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1203"/>
+        <source>Remove All Caches</source>
+        <translation>Удалить все кэши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1208"/>
+        <source>Remove Savestates</source>
+        <translation>Удалить сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1213"/>
+        <source>Clean up Game List</source>
+        <translation>Очистить список игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1218"/>
+        <source>Skylanders Portal</source>
+        <translation>Skylanders Portal</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1223"/>
+        <source>Infinity Base</source>
+        <translation>Infinity Base</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1228"/>
+        <source>Dimensions Toypad</source>
+        <translation>Dimensions Toypad</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1233"/>
+        <source>Kamen Rider Ride Gate</source>
+        <translation>Kamen Rider Ride Gate</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1238"/>
+        <source>Cheats</source>
+        <translation>Читы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1246"/>
+        <source>English</source>
+        <translation>English</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1251"/>
+        <source>Screenshots</source>
+        <translation>Скриншоты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1256"/>
+        <source>Remove Firmware Cache</source>
+        <translation>Удалить кэш прошивки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1261"/>
+        <source>Create Firmware Cache</source>
+        <translation>Создать кэш прошивки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1269"/>
+        <source>Create RSX Capture</source>
+        <translation>Создать RSX Capture</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1277"/>
+        <source>Create Savestate</source>
+        <translation>Создать сохранение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1285"/>
+        <source>Stop And Create Savestate</source>
+        <translation>Остановить и создать сохранение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1290"/>
+        <source>Game Patches</source>
+        <translation>Патчи игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1298"/>
+        <source>Configure RPCN</source>
+        <translation>Настройка RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1303"/>
+        <source>Clans</source>
+        <translation>Кланы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1306"/>
+        <source>Configure Clans</source>
+        <translation>Настройка кланов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1311"/>
+        <source>IPC</source>
+        <translation>IPC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1314"/>
+        <source>Configure IPC</source>
+        <translation>Настройка IPC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1319"/>
+        <source>Log Viewer</source>
+        <translation>Просмотрщик журнала</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1330"/>
+        <source>Show Custom Icons</source>
+        <translation>Показывать пользовательские иконки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1341"/>
+        <source>Play Hover Gifs</source>
+        <translation>Воспроизводить GIF при наведении</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1346"/>
+        <source>Boot VSH/XMB</source>
+        <translation>Запустить VSH/XMB</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1351"/>
+        <source>Patch Creator</source>
+        <translation>Создатель патчей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1356"/>
+        <source>Cameras</source>
+        <translation>Камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1364"/>
+        <source>Eject Disc</source>
+        <translation>Извлечь диск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1372"/>
+        <source>Insert Disc</source>
+        <translation>Вставить диск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1377"/>
+        <source>Check Config</source>
+        <translation>Проверить конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1382"/>
+        <source>Shortcuts</source>
+        <translation>Горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1390"/>
+        <source>System Commands</source>
+        <translation>Системные команды</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1395"/>
+        <source>Buzz</source>
+        <translation>Buzz</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1400"/>
+        <source>GHLtar</source>
+        <translation>GHLtar</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1405"/>
+        <source>Turntable</source>
+        <translation>Turntable</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1410"/>
+        <source>USIO</source>
+        <translation>USIO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1415"/>
+        <source>PS Move (Fake)</source>
+        <translation>PS Move (Имитация)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1420"/>
+        <source>PS Move (Mouse)</source>
+        <translation>PS Move (Мышь)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1425"/>
+        <source>GunCon 3</source>
+        <translation>GunCon 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1430"/>
+        <source>Top Shot Elite</source>
+        <translation>Top Shot Elite</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1435"/>
+        <source>Top Shot Fearmaster</source>
+        <translation>Top Shot Fearmaster</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1440"/>
+        <source>Logitech G27 Wheel</source>
+        <translation>Logitech G27 Wheel</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1445"/>
+        <source>Basic Mouse</source>
+        <translation>Базовая мышь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1450"/>
+        <source>Raw Mouse</source>
+        <translation>Прямой ввод мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1455"/>
+        <source>VFS Tool</source>
+        <translation>Инструмент VFS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1460"/>
+        <source>PS Move Tracker</source>
+        <translation>PS Move Tracker</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1465"/>
+        <source>PS Move</source>
+        <translation>PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1473"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3356"/>
+        <source>Operating System</source>
+        <translation>Операционная система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1491"/>
+        <source>Savestates</source>
+        <translation>Сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1499"/>
+        <source>Prefer Game Data Icons</source>
+        <translation>Предпочитать иконки данных игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1504"/>
+        <source>Music Player</source>
+        <translation>Музыкальный плеер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1509"/>
+        <source>Sound Effects</source>
+        <translation>Звуковые эффекты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1514"/>
+        <source>Download Update</source>
+        <translation>Загрузить обновление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1519"/>
+        <source>Add ISO Games</source>
+        <translation>Добавить ISO-игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.ui" line="1524"/>
+        <source>Boot ISO</source>
+        <translation>Запустить ISO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="221"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1946"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2008"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3589"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3599"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3612"/>
+        <source>Play %0</source>
+        <translation>Играть в %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="221"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1931"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1956"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2015"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3592"/>
+        <source>Play</source>
+        <translation>Играть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="225"/>
+        <source>&amp;Play Last Played Game</source>
+        <translation>&amp;Запустить последнюю игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="324"/>
+        <source>Missing Firmware Detected!</source>
+        <translation>Прошивка не обнаружена!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="325"/>
+        <source>Commercial games require the firmware (PS3UPDAT.PUP file) to be installed.
+&lt;br&gt;For information about how to obtain the required firmware read the &lt;a %0 href=&quot;https://rpcs3.net/quickstart&quot;&gt;quickstart guide&lt;/a&gt;.</source>
+        <translation>Коммерческие игры требуют установленной прошивки (файл PS3UPDAT.PUP).
+&lt;br&gt;Информацию о получении прошивки читайте в &lt;a %0 href=&quot;https://rpcs3.net/quickstart&quot;&gt;руководстве по быстрому старту&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="331"/>
+        <source>Locate PS3UPDAT.PUP</source>
+        <translation>Найти PS3UPDAT.PUP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="460"/>
+        <source>No bootable content was found.</source>
+        <translation>Загрузочный контент не найден.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="463"/>
+        <source>Disc could not be mounted properly. Make sure the disc is not in the dev_hdd0/game folder.</source>
+        <translation>Не удалось смонтировать диск. Убедитесь, что диск не находится в папке dev_hdd0/game.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="466"/>
+        <source>The selected file or folder is invalid or corrupted.</source>
+        <translation>Выбранный файл или папка недопустимы или повреждены.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="469"/>
+        <source>The virtual dev_bdvd folder does not exist or is not empty.</source>
+        <translation>Виртуальная папка dev_bdvd не существует или не пуста.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="472"/>
+        <source>Additional content could not be installed.</source>
+        <translation>Не удалось установить дополнительный контент.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="475"/>
+        <source>Digital content could not be decrypted. This is usually caused by a missing or invalid license (RAP) file.</source>
+        <translation>Не удалось расшифровать цифровой контент. Обычно это вызвано отсутствием или недействительностью файла лицензии (RAP).</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="478"/>
+        <source>The emulator could not create files required for booting.</source>
+        <translation>Эмулятор не смог создать файлы, необходимые для запуска.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="481"/>
+        <source>This disc type is not supported yet.</source>
+        <translation>Этот тип диска пока не поддерживается.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="484"/>
+        <source>Savestate data is corrupted or it&apos;s not an RPCS3 savestate.</source>
+        <translation>Данные сохранения повреждены или не являются сохранением RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="487"/>
+        <source>Savestate versioning data differs from your RPCS3 build.</source>
+        <translation>Версия данных сохранения отличается от вашей сборки RPCS3.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="490"/>
+        <source>A game or PS3 application is still running or has yet to be fully stopped.</source>
+        <translation>Игра или приложение PS3 ещё запущены или не полностью остановлены.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="493"/>
+        <source>The game or PS3 application needs a more recent firmware version.</source>
+        <translation>Игре или приложению PS3 требуется более новая версия прошивки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="501"/>
+        <source>Unknown error.</source>
+        <translation>Неизвестная ошибка.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="504"/>
+        <source>&lt;br /&gt;&lt;br /&gt;For information on setting up the emulator and dumping your PS3 games, read the &lt;a %0 href=&quot;https://rpcs3.net/quickstart&quot;&gt;quickstart guide&lt;/a&gt;.</source>
+        <translation>&lt;br /&gt;&lt;br /&gt;Информацию о настройке эмулятора и создании образов PS3-игр читайте в &lt;a %0 href=&quot;https://rpcs3.net/quickstart&quot;&gt;руководстве по быстрому старту&lt;/a&gt;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="507"/>
+        <source>Boot Failed</source>
+        <translation>Запуск не удался</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="511"/>
+        <source>Booting failed: %1 %2</source>
+        <translation>Запуск не удался: %1 %2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="575"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="623"/>
+        <source>Select (S)ELF To Boot</source>
+        <translation>Выбрать (S)ELF для запуска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="575"/>
+        <source>(S)ELF files (*BOOT.BIN *.elf *.self);;ELF files (BOOT.BIN *.elf);;SELF files (EBOOT.BIN *.self);;BOOT files (*BOOT.BIN);;BIN files (*.bin);;ISO files (*.iso);;All executable files (*.SAVESTAT.zst *.SAVESTAT.gz *.SAVESTAT *.sprx *.SPRX *.self *.SELF *.bin *.BIN *.prx *.PRX *.elf *.ELF *.o *.O);;All files (*.*)</source>
+        <translation>(S)ELF files (*BOOT.BIN *.elf *.self);;ELF files (BOOT.BIN *.elf);;SELF files (EBOOT.BIN *.self);;BOOT files (*BOOT.BIN);;BIN files (*.bin);;ISO files (*.iso);;All executable files (*.SAVESTAT.zst *.SAVESTAT.gz *.SAVESTAT *.sprx *.SPRX *.self *.SELF *.bin *.BIN *.prx *.PRX *.elf *.ELF *.o *.O);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="623"/>
+        <source>(S)ELF files (*.elf *.self);;ELF files (*.elf);;SELF files (*.self);;All files (*.*)</source>
+        <translation>(S)ELF files (*.elf *.self);;ELF files (*.elf);;SELF files (*.self);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="655"/>
+        <source>Select Savestate To Boot</source>
+        <translation>Выбрать сохранение для запуска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="655"/>
+        <source>Savestate files (*.SAVESTAT *.SAVESTAT.zst *.SAVESTAT.gz);;All files (*.*)</source>
+        <translation>Savestate files (*.SAVESTAT *.SAVESTAT.zst *.SAVESTAT.gz);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="686"/>
+        <source>Select Game Folder</source>
+        <translation>Выбрать папку с игрой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="714"/>
+        <source>Select ISO</source>
+        <translation>Выбрать ISO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="714"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2582"/>
+        <source>ISO files (*.iso);;All files (*.*)</source>
+        <translation>ISO files (*.iso);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="749"/>
+        <source>Select RSX Capture</source>
+        <translation>Выбрать RSX Capture</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="749"/>
+        <source>RRC files (*.rrc *.RRC *.rrc.gz *.RRC.GZ);;All files (*.*)</source>
+        <translation>RRC files (*.rrc *.RRC *.rrc.gz *.RRC.GZ);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="827"/>
+        <source>Select packages and/or rap files to install</source>
+        <translation>Выбрать пакеты и/или RAP-файлы для установки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="828"/>
+        <source>All relevant (*.pkg *.PKG *.rap *.RAP *.edat *.EDAT);;Package files (*.pkg *.PKG);;Rap files (*.rap *.RAP);;Edat files (*.edat *.EDAT);;All files (*.*)</source>
+        <translation>All relevant (*.pkg *.PKG *.rap *.RAP *.edat *.EDAT);;Package files (*.pkg *.PKG);;Rap files (*.rap *.RAP);;Edat files (*.edat *.EDAT);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="984"/>
+        <source>RPCS3 Package Installer</source>
+        <translation>Установщик пакетов RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="984"/>
+        <source>Installing package, please wait...</source>
+        <translation>Установка пакета, пожалуйста подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="984"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1331"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1565"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1010"/>
+        <source>v.%0</source>
+        <comment>Package version for install progress dialog</comment>
+        <translation>v.%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1068"/>
+        <source>Installing package (%0/%1), please wait...
+
+%2</source>
+        <translation>Установка пакета (%0/%1), пожалуйста подождите...
+
+%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1173"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1667"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3973"/>
+        <source>Success!</source>
+        <translation>Успешно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1173"/>
+        <source>Successfully installed software from package(s)!</source>
+        <translation>Программное обеспечение из пакета(ов) успешно установлено!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1212"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1217"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1224"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1212"/>
+        <source>Package cannot be installed on top of the current data.
+Update is for version %1, but you have version %2.
+
+Tried to install: %3</source>
+        <translation>Пакет нельзя установить поверх текущих данных.
+Обновление предназначено для версии %1, а у вас версия %2.
+
+Попытка установить: %3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1217"/>
+        <source>Package cannot be installed on top of the current data.
+Update is for version %1, but you don&apos;t have any data installed.
+
+Tried to install: %2</source>
+        <translation>Пакет нельзя установить поверх текущих данных.
+Обновление предназначено для версии %1, но данные не установлены.
+
+Попытка установить: %2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1223"/>
+        <source>version %1</source>
+        <translation>версия %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1223"/>
+        <source>no data installed</source>
+        <translation>данные не установлены</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1224"/>
+        <source>Package cannot be installed on top of the current data.
+Update is for unknown version, but you have version %1.
+
+Tried to install: %2</source>
+        <translation>Пакет нельзя установить поверх текущих данных.
+Обновление предназначено для неизвестной версии, а у вас версия %1.
+
+Попытка установить: %2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1231"/>
+        <source>Failure!</source>
+        <translation>Ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1231"/>
+        <source>Failed to install software from package:
+%1!
+This is very likely caused by external interference from a faulty anti-virus software.
+Please add RPCS3 to your anti-virus&apos; whitelist or use better anti-virus software.</source>
+        <translation>Не удалось установить программу из пакета:
+%1!
+Вероятно, это вызвано вмешательством неисправного антивируса.
+Добавьте RPCS3 в белый список антивируса или используйте другой антивирус.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1244"/>
+        <source>Select MSELF To extract</source>
+        <translation>Выбрать MSELF для извлечения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1244"/>
+        <source>All mself files (*.mself *.MSELF);;All files (*.*)</source>
+        <translation>All mself files (*.mself *.MSELF);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1251"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1297"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1322"/>
+        <source>Extraction Directory</source>
+        <translation>Папка для извлечения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1265"/>
+        <source>Select PS3UPDAT.PUP To Install</source>
+        <translation>Выбрать PS3UPDAT.PUP для установки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1265"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1290"/>
+        <source>PS3 update file (PS3UPDAT.PUP);;All pup files (*.pup *.PUP);;All files (*.*)</source>
+        <translation>PS3 update file (PS3UPDAT.PUP);;All pup files (*.pup *.PUP);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1269"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1544"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1554"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1565"/>
+        <source>RPCS3 Firmware Installer</source>
+        <translation>Установщик прошивки RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1269"/>
+        <source>Install firmware: %1?</source>
+        <translation>Установить прошивку: %1?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1290"/>
+        <source>Select PS3UPDAT.PUP To extract</source>
+        <translation>Выбрать PS3UPDAT.PUP для извлечения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1315"/>
+        <source>Select TAR To extract</source>
+        <translation>Выбрать TAR для извлечения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1315"/>
+        <source>All tar files (*.tar *.TAR *.tar.aa.* *.TAR.AA.*);;All files (*.*)</source>
+        <translation>All tar files (*.tar *.TAR *.tar.aa.* *.TAR.AA.*);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1331"/>
+        <source>TAR Extraction</source>
+        <translation>Извлечение TAR</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1331"/>
+        <source>Extracting encrypted TARs
+Please wait...</source>
+        <translation>Извлечение зашифрованных TAR-файлов
+Пожалуйста подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1354"/>
+        <source>The following TAR file(s) could not be extracted:</source>
+        <translation>Следующие TAR-файлы не удалось извлечь:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1371"/>
+        <source>TAR extraction failed</source>
+        <translation>Ошибка извлечения TAR</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1381"/>
+        <source>Firmware Installation Failed</source>
+        <translation>Ошибка установки прошивки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1388"/>
+        <source>Firmware installation failed: The provided path is empty.</source>
+        <translation>Ошибка установки прошивки: указанный путь пуст.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1407"/>
+        <source>Firmware installation failed: The selected firmware file couldn&apos;t be opened.</source>
+        <translation>Ошибка установки прошивки: не удалось открыть файл прошивки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1418"/>
+        <source>Firmware installation failed: The provided file is empty.</source>
+        <translation>Ошибка установки прошивки: файл пуст.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1424"/>
+        <source>Firmware installation failed: The provided file is not a PUP file.</source>
+        <translation>Ошибка установки прошивки: файл не является PUP-файлом.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1430"/>
+        <source>Firmware installation failed: The provided file is incomplete. Try redownloading it.</source>
+        <translation>Ошибка установки прошивки: файл неполный. Попробуйте скачать его заново.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1445"/>
+        <source>Firmware installation failed: The provided file is corrupted.</source>
+        <translation>Ошибка установки прошивки: файл повреждён.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1451"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1464"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1518"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1539"/>
+        <source>Firmware installation failed: The provided file&apos;s contents are corrupted.</source>
+        <translation>Ошибка установки прошивки: содержимое файла повреждено.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1472"/>
+        <source>Firmware installation failed: Couldn&apos;t retrieve available disk space.</source>
+        <translation>Ошибка установки прошивки: не удалось определить доступное место на диске.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1479"/>
+        <source>Firmware installation failed: Out of disk space.</source>
+        <translation>Ошибка установки прошивки: недостаточно места на диске.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1492"/>
+        <source>Firmware extraction failed: VFS mounting failed.</source>
+        <translation>Ошибка извлечения прошивки: не удалось подключить VFS.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1499"/>
+        <source>Firmware installation failed: Firmware contents could not be extracted.</source>
+        <translation>Ошибка установки прошивки: не удалось извлечь содержимое прошивки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1544"/>
+        <source>Old firmware detected.
+The newest firmware version is %1 and you are trying to install version %2
+Continue installation?</source>
+        <translation>Обнаружена старая прошивка.
+Последняя версия прошивки — %1, а вы пытаетесь установить версию %2
+Продолжить установку?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1554"/>
+        <source>Firmware of version %1 has already been installed.
+Overwrite current installation with version %2?</source>
+        <translation>Прошивка версии %1 уже установлена.
+Заменить текущую установку версией %2?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1565"/>
+        <source>Installing firmware version %1
+Please wait...</source>
+        <translation>Установка прошивки версии %1
+Пожалуйста подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1598"/>
+        <source>Firmware installation failed: Firmware could not be decompressed</source>
+        <translation>Ошибка установки прошивки: не удалось распаковать прошивку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1607"/>
+        <source>The firmware contents could not be extracted.
+This is very likely caused by external interference from a faulty anti-virus software.
+Please add RPCS3 to your anti-virus&apos; whitelist or use better anti-virus software.</source>
+        <translation>Не удалось извлечь содержимое прошивки.
+Вероятно, это вызвано вмешательством неисправного антивируса.
+Добавьте RPCS3 в белый список антивируса или используйте другой антивирус.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1667"/>
+        <source>Successfully installed PS3 firmware and LLE Modules!</source>
+        <translation>Прошивка PS3 и LLE-модули успешно установлены!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1683"/>
+        <source>Select binary files</source>
+        <translation>Выбрать бинарные файлы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1683"/>
+        <source>All Binaries (*.bin *.BIN *.self *.SELF *.sprx *.SPRX *.sdat *.SDAT *.edat *.EDAT);;BIN files (*.bin *.BIN);;SELF files (*.self *.SELF);;SPRX files (*.sprx *.SPRX);;SDAT/EDAT files (*.sdat *.SDAT *.edat *.EDAT);;All files (*.*)</source>
+        <translation>All Binaries (*.bin *.BIN *.self *.SELF *.sprx *.SPRX *.sdat *.SDAT *.edat *.EDAT);;BIN files (*.bin *.BIN);;SELF files (*.self *.SELF);;SPRX files (*.sprx *.SPRX);;SDAT/EDAT files (*.sdat *.SDAT *.edat *.EDAT);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1707"/>
+        <source>Hint: KLIC (KLicense key) is a 16-byte long string. (32 hexadecimal characters, can be prefixed with &quot;KLIC=0x&quot; from the log message)
+And is logged with some sceNpDrm* functions when the game/application which owns &quot;%0&quot; is running.</source>
+        <translation>Подсказка: KLIC (ключ лицензии) — строка длиной 16 байт (32 шестнадцатеричных символа, может иметь префикс &quot;KLIC=0x&quot; из сообщения журнала).
+Записывается некоторыми функциями sceNpDrm* при работе игры/приложения, которому принадлежит &quot;%0&quot;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1715"/>
+        <source>Enter KLIC of %0</source>
+        <translation>Введите KLIC для %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1716"/>
+        <source>Decryption failed with provided KLIC.
+%0</source>
+        <translation>Расшифровка с предоставленным KLIC не удалась.
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1716"/>
+        <source>Hexadecimal value.</source>
+        <translation>Шестнадцатеричное значение.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1886"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1909"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1961"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3582"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3605"/>
+        <source>Restart %0</source>
+        <translation>Перезапустить %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1887"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1910"/>
+        <source>Pause %0</source>
+        <translation>Приостановить %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1888"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1911"/>
+        <source>Stop %0</source>
+        <translation>Остановить %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1892"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1913"/>
+        <source>&amp;Pause</source>
+        <translation>&amp;Пауза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1926"/>
+        <source>Resume %0</source>
+        <translation>Возобновить %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1928"/>
+        <source>&amp;Resume</source>
+        <translation>&amp;Возобновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="1948"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2012"/>
+        <source>&amp;Play</source>
+        <translation>&amp;Играть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2363"/>
+        <source>Precompile caches</source>
+        <translation>Предкомпилировать кэши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2365"/>
+        <source>Add desktop shortcut(s)</source>
+        <translation>Добавить ярлык(и) на рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2367"/>
+        <source>Add Start menu shortcut(s)</source>
+        <translation>Добавить ярлык(и) в меню «Пуск»</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2369"/>
+        <source>Add dock shortcut(s)</source>
+        <translation>Добавить ярлык(и) в Dock</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2371"/>
+        <source>Add launcher shortcut(s)</source>
+        <translation>Добавить ярлык(и) в меню приложений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2373"/>
+        <source>%1
+Would you like to precompile caches and install shortcuts to the installed software? (%2 new software detected)
+
+</source>
+        <translation>%1
+Хотите предкомпилировать кэши и установить ярлыки? (обнаружено новых программ: %2)
+
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2564"/>
+        <source>Select a folder containing one or more games</source>
+        <translation>Выбрать папку с одной или несколькими играми</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2582"/>
+        <source>Select ISO files to add</source>
+        <translation>Выбрать ISO-файлы для добавления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2683"/>
+        <source>Failed to locate log</source>
+        <translation>Не удалось найти журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2683"/>
+        <source>Failed to locate log files.
+Make sure that RPCS3.log and RPCS3.log.gz are writable and can be created without permission issues.</source>
+        <translation>Не удалось найти файлы журнала.
+Убедитесь, что файлы RPCS3.log и RPCS3.log.gz доступны для записи.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2740"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2763"/>
+        <source>Select RPCS3&apos;s log saving location (saving %0)</source>
+        <translation>Выбрать место сохранения журнала RPCS3 (сохранение %0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2856"/>
+        <source>Select Disc Game Folder</source>
+        <translation>Выбрать папку с дисковой игрой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2867"/>
+        <source>Failed to insert disc</source>
+        <translation>Не удалось вставить диск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="2867"/>
+        <source>Make sure that the emulation is running and that the selected path belongs to a valid disc game.</source>
+        <translation>Убедитесь, что эмуляция запущена и выбранный путь ведёт к корректной дисковой игре.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3019"/>
+        <source>Error: Emulation Running</source>
+        <translation>Ошибка: эмуляция запущена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3019"/>
+        <source>You need to stop the emulator before editing Clans connection information!</source>
+        <translation>Остановите эмулятор перед изменением параметров подключения кланов!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3152"/>
+        <source>Select rpcs3.log or config.yml</source>
+        <translation>Выбрать rpcs3.log или config.yml</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3152"/>
+        <source>Log or Config files (*.log *.gz *.txt *.yml);;Log files (*.log *.gz);;Config Files (*.yml);;Text Files (*.txt);;All files (*.*)</source>
+        <translation>Log or Config files (*.log *.gz *.txt *.yml);;Log files (*.log *.gz);;Config Files (*.yml);;Text Files (*.txt);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3163"/>
+        <source>Weird file!</source>
+        <translation>Необычный файл!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3163"/>
+        <source>This file seems to have an unexpected type:
+%0
+
+Check anyway?</source>
+        <translation>Этот файл имеет неожиданный тип:
+%0
+
+Проверить всё равно?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3195"/>
+        <source>Failed to open file</source>
+        <translation>Не удалось открыть файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3195"/>
+        <source>The file could not be opened:
+%0</source>
+        <translation>Не удалось открыть файл:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3366"/>
+        <source>Auto-updater</source>
+        <translation>Автообновление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3366"/>
+        <source>The auto-updater isn&apos;t available for your OS currently.</source>
+        <translation>Автообновление в данный момент недоступно для вашей ОС.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3759"/>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3799"/>
+        <source>Confirm Removal</source>
+        <translation>Подтвердить удаление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3759"/>
+        <source>Remove invalid game paths from game list?
+Undetectable games (zombies) as well as corrupted games will be removed from the game list file (games.yml)</source>
+        <translation>Удалить недопустимые пути игр из списка?
+Необнаруживаемые игры (зомби) и повреждённые игры будут удалены из файла списка игр (games.yml)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3789"/>
+        <source>Summary</source>
+        <translation>Сводка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3789"/>
+        <source>%0 game(s) removed from game list</source>
+        <translation>%0 игр(а) удалено из списка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3799"/>
+        <source>Remove firmware cache?</source>
+        <translation>Удалить кэш прошивки?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3969"/>
+        <source>Nothing to add!</source>
+        <translation>Нечего добавлять!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3969"/>
+        <source>Could not find any new software.</source>
+        <translation>Новое программное обеспечение не найдено.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="3973"/>
+        <source>Successfully added software to game list from path(s)!</source>
+        <translation>Программы успешно добавлены в список игр!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/main_window.cpp" line="4148"/>
+        <source>PARAM.SFO Information</source>
+        <translation>Информация PARAM.SFO</translation>
+    </message>
+</context>
+<context>
+    <name>memory_viewer_panel</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="69"/>
+        <source>Memory Viewer Of %0</source>
+        <translation>Просмотрщик памяти: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="70"/>
+        <source>Memory Viewer Of RSX[0x55555555]</source>
+        <translation>Просмотрщик памяти: RSX[0x55555555]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="71"/>
+        <source>Memory Viewer</source>
+        <translation>Просмотрщик памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="90"/>
+        <source>Memory Viewer Options</source>
+        <translation>Параметры просмотрщика памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="94"/>
+        <source>Address</source>
+        <translation>Адрес</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="107"/>
+        <source>Words</source>
+        <translation>Слова</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="135"/>
+        <source>Control</source>
+        <translation>Управление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="155"/>
+        <source>Refresh</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="171"/>
+        <source>Raw Image Preview Options</source>
+        <translation>Параметры предпросмотра изображения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="175"/>
+        <source>Size</source>
+        <translation>Размер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="190"/>
+        <source>Mode</source>
+        <translation>Режим</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="209"/>
+        <source>Tools</source>
+        <translation>Инструменты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="211"/>
+        <source>View
+image</source>
+        <translation>Просмотр
+изображения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="289"/>
+        <source>Memory Search</source>
+        <translation>Поиск в памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="296"/>
+        <source>Search...</source>
+        <translation>Поиск...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="299"/>
+        <source>Search</source>
+        <translation>Поиск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="302"/>
+        <source>Case Insensitive</source>
+        <translation>Без учёта регистра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="304"/>
+        <source>When using string mode, the characters&apos; case will not matter both in string and in memory.
+Warning: this may reduce performance of the search.</source>
+        <translation>В режиме строк регистр символов не учитывается ни в строке, ни в памяти.
+Внимание: это может снизить производительность поиска.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="308"/>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="352"/>
+        <source>Select search mode(s)..</source>
+        <translation>Выбрать режим(ы) поиска..</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="309"/>
+        <source>Deselect All Modes</source>
+        <translation>Сбросить все режимы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="310"/>
+        <source>String</source>
+        <translation>Строка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="311"/>
+        <source>HEX bytes/integer</source>
+        <translation>HEX байты/целое</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="312"/>
+        <source>Double</source>
+        <translation>Double</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="313"/>
+        <source>Float</source>
+        <translation>Float</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="314"/>
+        <source>Instruction</source>
+        <translation>Инструкция</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="315"/>
+        <source>RegEx Instruction</source>
+        <translation>RegEx-инструкция</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="317"/>
+        <source>String: search the memory for the specified string.
+HEX bytes/integer: search the memory for hexadecimal values. Spaces, commas, &quot;0x&quot;, &quot;0X&quot;, &quot;\x&quot;, &quot;h&quot;, &quot;H&quot; ensure separation of bytes but they are not mandatory.
+Double: reinterpret the string as 64-bit precision floating point value. Values are searched for exact representation, meaning -0 != 0.
+Float: reinterpret the string as 32-bit precision floating point value. Values are searched for exact representation, meaning -0 != 0.
+Instruction: search an instruction contains the text of the string.
+RegEx: search an instruction containing text that matches the regular expression input.</source>
+        <translation>String: поиск в памяти по заданной строке.
+HEX bytes/integer: поиск в памяти по шестнадцатеричным значениям. Пробелы, запятые, &quot;0x&quot;, &quot;0X&quot;, &quot;\x&quot;, &quot;h&quot;, &quot;H&quot; разделяют байты, но не обязательны.
+Double: строка как 64-битное число с плавающей точкой, поиск точного значения (-0 != 0).
+Float: строка как 32-битное число с плавающей точкой, поиск точного значения (-0 != 0).
+Instruction: поиск инструкции, содержащей текст строки.
+RegEx: поиск инструкции, соответствующей регулярному выражению.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="327"/>
+        <source>SPU RegEx-Instruction</source>
+        <translation>SPU RegEx-инструкция</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="328"/>
+        <source>
+SPU Instruction: Search an SPU instruction contains the text of the string. For searching instructions within embedded SPU images.
+Tip: SPU floats are commented along forming instructions.</source>
+        <translation>
+SPU Instruction: поиск SPU-инструкции, содержащей текст строки (в том числе во встроенных SPU-образах).
+Подсказка: SPU float-значения комментируются вместе с инструкциями.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/memory_viewer_panel.cpp" line="357"/>
+        <source>%0 mode(s) selected</source>
+        <translation>%0 режим(ов) выбрано</translation>
+    </message>
+</context>
+<context>
+    <name>microphone_creator</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/microphone_creator.cpp" line="19"/>
+        <source>None</source>
+        <comment>Microphone device</comment>
+        <translation>Нет</translation>
+    </message>
+</context>
+<context>
+    <name>midi_creator</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/midi_creator.cpp" line="19"/>
+        <source>None</source>
+        <comment>MIDI device</comment>
+        <translation>Нет</translation>
+    </message>
+</context>
+<context>
+    <name>minifig_creator_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="383"/>
+        <source>Figure Creator</source>
+        <translation>Создание фигурки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="399"/>
+        <source>--Unknown--</source>
+        <translation>--Неизвестно--</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="418"/>
+        <source>Figure Number:</source>
+        <translation>Номер фигурки:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="427"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="428"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="451"/>
+        <source>Error converting value</source>
+        <translation>Ошибка преобразования значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="451"/>
+        <source>Figure number entered is invalid!</source>
+        <translation>Введённый номер фигурки недействителен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="464"/>
+        <source>Create Figure File</source>
+        <translation>Создать файл фигурки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="464"/>
+        <source>Dimensions Figure (*.bin);;</source>
+        <translation>Фигурка Dimensions (*.bin);;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="473"/>
+        <source>Failed to create minifig file!</source>
+        <translation>Не удалось создать файл минифигурки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="473"/>
+        <source>Failed to create minifig file:
+%1</source>
+        <translation>Не удалось создать файл минифигурки:
+%1</translation>
+    </message>
+</context>
+<context>
+    <name>minifig_move_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="503"/>
+        <source>Figure Mover</source>
+        <translation>Перемещение фигурки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="540"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="542"/>
+        <source>Move Here</source>
+        <translation>Поместить сюда</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/dimensions_dialog.cpp" line="545"/>
+        <source>Pick up and Place</source>
+        <translation>Взять и разместить</translation>
+    </message>
+</context>
+<context>
+    <name>msg_dialog_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/msg_dialog_frame.cpp" line="17"/>
+        <source>Normal dialog</source>
+        <translation>Обычный диалог</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/msg_dialog_frame.cpp" line="17"/>
+        <source>Error dialog</source>
+        <translation>Диалог ошибки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/msg_dialog_frame.cpp" line="66"/>
+        <source>&amp;Yes</source>
+        <translation>&amp;Да</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/msg_dialog_frame.cpp" line="67"/>
+        <source>&amp;No</source>
+        <translation>&amp;Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/msg_dialog_frame.cpp" line="101"/>
+        <source>&amp;OK</source>
+        <translation>&amp;ОК</translation>
+    </message>
+</context>
+<context>
+    <name>music_player_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/music_player_dialog.ui" line="14"/>
+        <source>Music Player</source>
+        <translation>Музыкальный плеер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/music_player_dialog.ui" line="35"/>
+        <source>Select file</source>
+        <translation>Выбрать файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/music_player_dialog.ui" line="131"/>
+        <source>Vol:</source>
+        <translation>Гр:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/music_player_dialog.cpp" line="41"/>
+        <source>Select audio file</source>
+        <translation>Выбрать аудиофайл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/music_player_dialog.cpp" line="41"/>
+        <source>Audio files (*.mp3;*.wav;*.aac;*.ogg;*.flac;*.m4a;*.alac);;All files (*.*)</source>
+        <translation>Audio files (*.mp3;*.wav;*.aac;*.ogg;*.flac;*.m4a;*.alac);;All files (*.*)</translation>
+    </message>
+</context>
+<context>
+    <name>pad_led_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="14"/>
+        <source>LED Settings</source>
+        <translation>Настройки LED</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="26"/>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.cpp" line="54"/>
+        <source>LED Color</source>
+        <translation>Цвет LED</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="39"/>
+        <source>Select color</source>
+        <translation>Выбрать цвет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="49"/>
+        <source>Player LED</source>
+        <translation>LED игрока</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="55"/>
+        <source>Enable player LED</source>
+        <translation>Включить LED игрока</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="65"/>
+        <source>In-game battery status</source>
+        <translation>Статус батареи в игре</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="71"/>
+        <source>Blink LED when battery is low</source>
+        <translation>Мигать LED при низком заряде</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="78"/>
+        <source>Use LED as a battery indicator</source>
+        <translation>Использовать LED как индикатор батареи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="88"/>
+        <source>LED battery indicator brightness</source>
+        <translation>Яркость LED-индикатора батареи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_led_settings_dialog.ui" line="94"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+</context>
+<context>
+    <name>pad_motion_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="14"/>
+        <source>Motion Controls</source>
+        <translation>Гироскопическое управление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="20"/>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="32"/>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="45"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="88"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="131"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="174"/>
+        <source>0</source>
+        <translation>0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="58"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="101"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="144"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="187"/>
+        <source>Mirrored</source>
+        <translation>Зеркально</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="65"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="108"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="151"/>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="194"/>
+        <source>Shift: </source>
+        <translation>Смещение: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="75"/>
+        <source>Y</source>
+        <translation>Y</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="118"/>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="161"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="247"/>
+        <source>OK</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.ui" line="254"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.cpp" line="47"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_motion_settings_dialog.h" line="67"/>
+        <source> (disconnected)</source>
+        <translation> (отключено)</translation>
+    </message>
+</context>
+<context>
+    <name>pad_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="17"/>
+        <source>Configure Keyboard</source>
+        <translation>Настройка клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="46"/>
+        <source>Tab 1</source>
+        <translation>Вкладка 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="66"/>
+        <source>Handlers</source>
+        <translation>Обработчики</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="87"/>
+        <source>Refresh</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="100"/>
+        <source>Devices</source>
+        <translation>Устройства</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="124"/>
+        <source>Motion Controls</source>
+        <translation>Гироскопическое управление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="142"/>
+        <source>Configure</source>
+        <translation>Настроить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="152"/>
+        <source>Configuration Files</source>
+        <translation>Файлы конфигурации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="173"/>
+        <source>Add New</source>
+        <translation>Добавить новую</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="183"/>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="205"/>
+        <source>D-Pad</source>
+        <translation>D-Pad</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="257"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="494"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="512"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2142"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1804"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1806"/>
+        <source>Up</source>
+        <translation>Вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="275"/>
+        <source>W</source>
+        <translation>W</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="306"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="543"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="561"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2191"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2351"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2432"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2676"/>
+        <source>Left</source>
+        <translation>Влево</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="324"/>
+        <source>A</source>
+        <translation>A</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="337"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="574"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="592"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2222"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2381"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2459"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2706"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1808"/>
+        <source>Right</source>
+        <translation>Вправо</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="355"/>
+        <source>D</source>
+        <translation>D</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="398"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="635"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="653"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2283"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1805"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1807"/>
+        <source>Down</source>
+        <translation>Вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="416"/>
+        <source>S</source>
+        <translation>S</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="448"/>
+        <source>Left Stick</source>
+        <translation>Левый стик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="685"/>
+        <source>Orientation Reset</source>
+        <translation>Сброс ориентации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="703"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="754"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="805"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="726"/>
+        <source>Orientation</source>
+        <translation>Ориентация</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="736"/>
+        <source>Analog Limiter</source>
+        <translation>Ограничитель аналога</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="777"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="825"/>
+        <source>Toggle</source>
+        <translation>Переключить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="787"/>
+        <source>Pressure Sensitivity Mode</source>
+        <translation>Режим чувствительности к давлению</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="812"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="968"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="978"/>
+        <source>%</source>
+        <translation>%</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="835"/>
+        <source>Pressure Sensitivity Deadzone</source>
+        <translation>Мёртвая зона чувствительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="891"/>
+        <source>Trigger Thresholds</source>
+        <translation>Пороги триггеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="948"/>
+        <source>Enable Vibration</source>
+        <translation>Включить вибрацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="971"/>
+        <source>Small </source>
+        <translation>Малая </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="981"/>
+        <source>Large </source>
+        <translation>Большая </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="992"/>
+        <source>Threshold </source>
+        <translation>Порог </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1002"/>
+        <source>Switch</source>
+        <translation>Переключатель</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1043"/>
+        <source>Mouse Acceleration</source>
+        <translation>Ускорение мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1061"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1142"/>
+        <source>x</source>
+        <translation>x</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1091"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1168"/>
+        <source>y</source>
+        <translation>y</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1124"/>
+        <source>Mouse Deadzone</source>
+        <translation>Мёртвая зона мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1197"/>
+        <source>Mouse Movement Mode</source>
+        <translation>Режим движения мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1271"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1809"/>
+        <source>L1</source>
+        <translation>L1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1289"/>
+        <source>Q</source>
+        <translation>Q</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1302"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1810"/>
+        <source>L2</source>
+        <translation>L2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1320"/>
+        <source>R</source>
+        <translation>R</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1355"/>
+        <source>Select</source>
+        <translation>Select</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1373"/>
+        <source>Space</source>
+        <translation>Space</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1386"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1404"/>
+        <source>Enter</source>
+        <translation>Enter</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1463"/>
+        <source>PS Button</source>
+        <translation>Кнопка PS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1481"/>
+        <source>Backspace</source>
+        <translation>Backspace</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1514"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1812"/>
+        <source>R1</source>
+        <translation>R1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1532"/>
+        <source>E</source>
+        <translation>E</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1545"/>
+        <source>R2</source>
+        <translation>R2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1563"/>
+        <source>T</source>
+        <translation>T</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1641"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1811"/>
+        <source>L3</source>
+        <translation>L3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1659"/>
+        <source>F</source>
+        <translation>F</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1672"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1813"/>
+        <source>R3</source>
+        <translation>R3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1690"/>
+        <source>G</source>
+        <translation>G</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1723"/>
+        <source>Device Class</source>
+        <translation>Класс устройства</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1756"/>
+        <source>Battery status and LED</source>
+        <translation>Статус батареи и LED</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1796"/>
+        <source>LED Settings</source>
+        <translation>Настройки LED</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1824"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1859"/>
+        <source>Face Buttons</source>
+        <translation>Кнопки лица</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1905"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1803"/>
+        <source>Triangle</source>
+        <translation>Triangle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1923"/>
+        <source>V</source>
+        <translation>V</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1954"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1802"/>
+        <source>Square</source>
+        <translation>Square</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1972"/>
+        <source>Z</source>
+        <translation>Z</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="1985"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1801"/>
+        <source>Circle</source>
+        <translation>Circle</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2003"/>
+        <source>C</source>
+        <translation>C</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2046"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1800"/>
+        <source>Cross</source>
+        <translation>Cross</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2064"/>
+        <source>X</source>
+        <translation>X</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2096"/>
+        <source>Right Stick</source>
+        <translation>Правый стик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2160"/>
+        <source>PgUp</source>
+        <translation>PgUp</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2209"/>
+        <source>Home</source>
+        <translation>Главная</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2240"/>
+        <source>End</source>
+        <translation>End</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2301"/>
+        <source>PgDown</source>
+        <translation>PgDown</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2333"/>
+        <source>Squircle Values</source>
+        <translation>Значения сквиркля</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2414"/>
+        <source>Stick Multipliers</source>
+        <translation>Множители стиков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2508"/>
+        <source>Analog Stick Deadzones</source>
+        <translation>Мёртвые зоны стиков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2543"/>
+        <source>Analog Stick Anti-Deadzones</source>
+        <translation>Анти-мёртвые зоны стиков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2578"/>
+        <source>Stick Preview</source>
+        <translation>Предпросмотр стиков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2596"/>
+        <source>Show Emulated Values</source>
+        <translation>Показывать эмулируемые значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.ui" line="2658"/>
+        <source>Stick Interpolation</source>
+        <translation>Интерполяция стиков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="78"/>
+        <source>Gamepad Settings: [%0] %1</source>
+        <translation>Настройки геймпада: [%0] %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="82"/>
+        <source>Gamepad Settings</source>
+        <translation>Настройки геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="108"/>
+        <source>Player %0</source>
+        <translation>Игрок %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="138"/>
+        <source>Filter Noise</source>
+        <translation>Фильтр помех</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="163"/>
+        <source>Standard (Pad)</source>
+        <translation>Стандартный (геймпад)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="164"/>
+        <source>Guitar</source>
+        <translation>Гитара</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="165"/>
+        <source>Drum</source>
+        <translation>Барабаны</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="166"/>
+        <source>DJ</source>
+        <translation>DJ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="167"/>
+        <source>Dance Mat</source>
+        <translation>Танцевальный коврик</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="168"/>
+        <source>PS Move Navigation</source>
+        <translation>PS Move Navigation</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="169"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2170"/>
+        <source>Skateboard</source>
+        <translation>Скейтборд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="170"/>
+        <source>GunCon 3</source>
+        <translation>GunCon 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="171"/>
+        <source>Top Shot Elite</source>
+        <translation>Top Shot Elite</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="172"/>
+        <source>Top Shot Fearmaster</source>
+        <translation>Top Shot Fearmaster</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="173"/>
+        <source>uDraw GameTablet</source>
+        <translation>uDraw GameTablet</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="174"/>
+        <source>Copilot for Player 1</source>
+        <translation>Второй игрок для игрока 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="175"/>
+        <source>Copilot for Player 2</source>
+        <translation>Второй игрок для игрока 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="176"/>
+        <source>Copilot for Player 3</source>
+        <translation>Второй игрок для игрока 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="177"/>
+        <source>Copilot for Player 4</source>
+        <translation>Второй игрок для игрока 4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="178"/>
+        <source>Copilot for Player 5</source>
+        <translation>Второй игрок для игрока 5</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="179"/>
+        <source>Copilot for Player 6</source>
+        <translation>Второй игрок для игрока 6</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="180"/>
+        <source>Copilot for Player 7</source>
+        <translation>Второй игрок для игрока 7</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="203"/>
+        <source>Relative</source>
+        <translation>Относительный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="204"/>
+        <source>Absolute</source>
+        <translation>Абсолютный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="353"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1391"/>
+        <source>[ Waiting %1 ]</source>
+        <translation>[ Ожидание %1 ]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1556"/>
+        <source>Custom Controller</source>
+        <translation>Пользовательский контроллер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1610"/>
+        <source>No Device Detected</source>
+        <translation>Устройство не обнаружено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1721"/>
+        <source>PS3 Controller</source>
+        <comment>PlayStation 3 Controller</comment>
+        <translation>Контроллер PS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1726"/>
+        <source>Dance Dance Revolution</source>
+        <comment>Dance Dance Revolution Mat</comment>
+        <translation>Dance Dance Revolution</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1731"/>
+        <source>DJ Hero Turntable</source>
+        <comment>DJ Hero Turntable</comment>
+        <translation>DJ Hero Turntable</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1736"/>
+        <source>Rock Band</source>
+        <comment>Harmonix Rock Band Drum Kit</comment>
+        <translation>Rock Band</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1741"/>
+        <source>Rock Band Pro</source>
+        <comment>Harmonix Rock Band Pro-Drum Kit</comment>
+        <translation>Rock Band Pro</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1746"/>
+        <source>Rock Band</source>
+        <comment>Harmonix Rock Band Guitar</comment>
+        <translation>Rock Band</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1751"/>
+        <source>Guitar Hero</source>
+        <comment>RedOctane Guitar Hero Drum Kit</comment>
+        <translation>Guitar Hero</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1756"/>
+        <source>Guitar Hero</source>
+        <comment>RedOctane Guitar Hero Guitar</comment>
+        <translation>Guitar Hero</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1761"/>
+        <source>Rock Revolution</source>
+        <comment>Rock Revolution Drum Controller</comment>
+        <translation>Rock Revolution</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1766"/>
+        <source>PS Move Navigation</source>
+        <comment>PS Move Navigation Controller</comment>
+        <translation>PS Move Navigation</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1771"/>
+        <source>RIDE Skateboard</source>
+        <comment>Tony Hawk RIDE Skateboard Controller</comment>
+        <translation>RIDE Skateboard</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1776"/>
+        <source>GunCon 3</source>
+        <comment>GunCon 3 Controller</comment>
+        <translation>GunCon 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1781"/>
+        <source>Top Shot Elite</source>
+        <comment>Top Shot Elite Controller</comment>
+        <translation>Top Shot Elite</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1786"/>
+        <source>Top Shot Fearmaster</source>
+        <comment>Top Shot Fearmaster Controller</comment>
+        <translation>Top Shot Fearmaster</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1791"/>
+        <source>uDraw GameTablet</source>
+        <comment>uDraw GameTablet Controller</comment>
+        <translation>uDraw GameTablet</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1819"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1831"/>
+        <source>Green Fret</source>
+        <translation>Зелёный лад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1820"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1832"/>
+        <source>Red Fret</source>
+        <translation>Красный лад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1821"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1834"/>
+        <source>Yellow Fret</source>
+        <translation>Жёлтый лад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1822"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1833"/>
+        <source>Blue Fret</source>
+        <translation>Синий лад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1823"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1835"/>
+        <source>Strum Up</source>
+        <translation>Удар вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1824"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1836"/>
+        <source>Strum Down</source>
+        <translation>Удар вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1825"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1839"/>
+        <source>Whammy</source>
+        <translation>Вибрато</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1826"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1840"/>
+        <source>Orange Fret</source>
+        <translation>Оранжевый лад</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1837"/>
+        <source>Pickup Switch Up</source>
+        <translation>Переключатель звукоснимателя вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1838"/>
+        <source>Pickup Switch Down</source>
+        <translation>Переключатель звукоснимателя вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1841"/>
+        <source>Solo Modifier</source>
+        <translation>Модификатор соло</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1842"/>
+        <source>Tilt</source>
+        <translation>Наклон</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1847"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1857"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1866"/>
+        <source>Green Pad</source>
+        <translation>Зелёный пэд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1848"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1858"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1867"/>
+        <source>Red Pad</source>
+        <translation>Красный пэд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1849"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1859"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1868"/>
+        <source>Blue Pad</source>
+        <translation>Синий пэд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1850"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1860"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1869"/>
+        <source>Yellow Pad</source>
+        <translation>Жёлтый пэд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1851"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1861"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1870"/>
+        <source>Foot Pedal</source>
+        <translation>Педаль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1852"/>
+        <source>Orange Pad</source>
+        <translation>Оранжевый пэд</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1871"/>
+        <source>Pad Modifier</source>
+        <translation>Модификатор пэда</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1872"/>
+        <source>Double Bass Pedal</source>
+        <translation>Двойная бас-педаль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1873"/>
+        <source>Cymbal Modifier</source>
+        <translation>Модификатор тарелки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1901"/>
+        <source>Choose a unique name</source>
+        <translation>Введите уникальное имя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1902"/>
+        <source>Configuration Name: </source>
+        <translation>Имя конфигурации: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1911"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1916"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1921"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1911"/>
+        <source>Name cannot be empty</source>
+        <translation>Имя не может быть пустым</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1916"/>
+        <source>Must choose a name without &apos;.&apos;</source>
+        <translation>Имя не должно содержать &apos;.&apos;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1921"/>
+        <source>Please choose a non-existing name</source>
+        <translation>Пожалуйста, введите несуществующее имя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1940"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1953"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2122"/>
+        <source>Warning!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1940"/>
+        <source>Can&apos;t remove default configuration &apos;%0&apos;.</source>
+        <translation>Нельзя удалить конфигурацию по умолчанию &apos;%0&apos;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1944"/>
+        <source>Remove Configuration?</source>
+        <translation>Удалить конфигурацию?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1944"/>
+        <source>Do you really want to remove the configuration &apos;%0&apos;?</source>
+        <translation>Вы действительно хотите удалить конфигурацию &apos;%0&apos;?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1953"/>
+        <source>Failed to remove &apos;%0&apos;.</source>
+        <translation>Не удалось удалить &apos;%0&apos;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1968"/>
+        <source>Removed Configuration</source>
+        <translation>Конфигурация удалена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1968"/>
+        <source>Removed configuration &apos;%0&apos;.
+The selected configuration is now &apos;%1&apos;.</source>
+        <translation>Конфигурация &apos;%0&apos; удалена.
+Текущая конфигурация: &apos;%1&apos;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="1981"/>
+        <source>Reserved</source>
+        <translation>Зарезервировано</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2123"/>
+        <source>The %0 button &lt;b&gt;%1&lt;/b&gt; of &lt;b&gt;Player %2&lt;/b&gt; was assigned at least twice.&lt;br&gt;Please consider adjusting the configuration.&lt;br&gt;&lt;br&gt;Continue anyway?&lt;br&gt;</source>
+        <translation>Кнопка %0 &lt;b&gt;%1&lt;/b&gt; для &lt;b&gt;игрока %2&lt;/b&gt; назначена как минимум дважды.&lt;br&gt;Рекомендуется скорректировать конфигурацию.&lt;br&gt;&lt;br&gt;Продолжить всё равно?&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2165"/>
+        <source>Null</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2166"/>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2191"/>
+        <source>Keyboard</source>
+        <translation>Клавиатура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2167"/>
+        <source>DualShock 3</source>
+        <translation>DualShock 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2168"/>
+        <source>DualShock 4</source>
+        <translation>DualShock 4</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2169"/>
+        <source>DualSense</source>
+        <translation>DualSense</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2171"/>
+        <source>PS Move</source>
+        <translation>PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2173"/>
+        <source>XInput</source>
+        <translation>XInput</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2174"/>
+        <source>MMJoystick</source>
+        <translation>MMJoystick</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2177"/>
+        <source>SDL</source>
+        <translation>SDL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2180"/>
+        <source>Evdev</source>
+        <translation>Evdev</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2190"/>
+        <source>Default Null Device</source>
+        <translation>Устройство по умолчанию (нет)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2192"/>
+        <source>DS3 Pad #%0</source>
+        <translation>DS3 Pad #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2193"/>
+        <source>DS4 Pad #%0</source>
+        <translation>DS4 Pad #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2194"/>
+        <source>DualSense Pad #%0</source>
+        <translation>DualSense Pad #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2195"/>
+        <source>Skateboard #%0</source>
+        <translation>Скейтборд #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2196"/>
+        <source>PS Move #%0</source>
+        <translation>PS Move #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2198"/>
+        <source>XInput Pad #%0</source>
+        <translation>XInput Pad #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.cpp" line="2199"/>
+        <source>Joystick #%0</source>
+        <translation>Джойстик #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pad_settings_dialog.h" line="90"/>
+        <source> (disconnected)</source>
+        <translation> (отключено)</translation>
+    </message>
+</context>
+<context>
+    <name>patch_creator_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="14"/>
+        <source>Patch Creator</source>
+        <translation>Создатель патчей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="37"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="42"/>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="65"/>
+        <source>Offset</source>
+        <translation>Смещение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="47"/>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="72"/>
+        <source>Value</source>
+        <translation>Значение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="52"/>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="79"/>
+        <source>Comment</source>
+        <translation>Комментарий</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="86"/>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="104"/>
+        <source>Hash</source>
+        <translation>Хеш</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="113"/>
+        <source>Patch Version</source>
+        <translation>Версия патча</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="131"/>
+        <source>Notes</source>
+        <translation>Заметки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="138"/>
+        <source>Author</source>
+        <translation>Автор</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="145"/>
+        <source>Group</source>
+        <translation>Группа</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="152"/>
+        <source>Patch Name</source>
+        <translation>Имя патча</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="159"/>
+        <source>Game</source>
+        <translation>Игра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="166"/>
+        <source>Title ID</source>
+        <translation>ID названия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="173"/>
+        <source>Game Versions</source>
+        <translation>Версии игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.ui" line="180"/>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="392"/>
+        <source>Valid Patch</source>
+        <translation>Корректный патч</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="137"/>
+        <source>&amp;Add Instruction</source>
+        <translation>&amp;Добавить инструкцию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="147"/>
+        <source>&amp;Add Instruction Above</source>
+        <translation>&amp;Добавить инструкцию выше</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="153"/>
+        <source>&amp;Add Instruction Below</source>
+        <translation>&amp;Добавить инструкцию ниже</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="167"/>
+        <source>&amp;Move Instruction(s) Up</source>
+        <translation>&amp;Переместить инструкцию(и) вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="179"/>
+        <source>&amp;Move Instruction(s) Down</source>
+        <translation>&amp;Переместить инструкцию(и) вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="188"/>
+        <source>&amp;Remove Instruction(s)</source>
+        <translation>&amp;Удалить инструкцию(и)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="197"/>
+        <source>&amp;Clear Table</source>
+        <translation>&amp;Очистить таблицу</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="248"/>
+        <source>Offset invalid!</source>
+        <translation>Смещение недействительно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="248"/>
+        <source>The patch offset is invalid.
+The offset has to be a hexadecimal number with 8 digits at most.</source>
+        <translation>Смещение патча недействительно.
+Смещение должно быть шестнадцатеричным числом не более 8 цифр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="398"/>
+        <source>Validation Failed</source>
+        <translation>Проверка не пройдена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="456"/>
+        <source>Patch invalid!</source>
+        <translation>Патч недействителен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="456"/>
+        <source>The patch validation failed.
+The export of invalid patches is not allowed.</source>
+        <translation>Проверка патча не пройдена.
+Экспорт недействительных патчей запрещён.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="460"/>
+        <source>Select Patch File</source>
+        <translation>Выбрать файл патча</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="460"/>
+        <source>patch.yml files (*.yml);;All files (*.*)</source>
+        <translation>patch.yml files (*.yml);;All files (*.*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_creator_dialog.cpp" line="525"/>
+        <source>Instruction %0: Type &apos;%1&apos; is invalid!</source>
+        <translation>Инструкция %0: тип &apos;%1&apos; недействителен!</translation>
+    </message>
+</context>
+<context>
+    <name>patch_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="17"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1025"/>
+        <source>Patch Manager</source>
+        <translation>Менеджер патчей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="38"/>
+        <source>Filter patches</source>
+        <translation>Фильтр патчей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="45"/>
+        <source>Only show owned games</source>
+        <translation>Только игры в наличии</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="106"/>
+        <source>Patch Information</source>
+        <translation>Информация о патче</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="112"/>
+        <source>Game Title</source>
+        <translation>Название игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="134"/>
+        <source>Serial</source>
+        <translation>Серийный номер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="156"/>
+        <source>Game Version</source>
+        <translation>Версия игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="175"/>
+        <source>Hash</source>
+        <translation>Хеш</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="197"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="219"/>
+        <source>Patch Version</source>
+        <translation>Версия патча</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="241"/>
+        <source>Author</source>
+        <translation>Автор</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="263"/>
+        <source>Notes</source>
+        <translation>Заметки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="288"/>
+        <source>Configurable Values</source>
+        <translation>Настраиваемые значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="294"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.ui" line="301"/>
+        <source>N/A</source>
+        <translation>Н/Д</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="240"/>
+        <source>Incompatible patches detected</source>
+        <translation>Обнаружены несовместимые патчи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="241"/>
+        <source>Some of your patches are not compatible with the current version of RPCS3&apos;s Patch Manager.
+
+Make sure that all the patches located in &quot;%0&quot; contain the proper formatting that is required for the Patch Manager Version %1.</source>
+        <translation>Некоторые патчи несовместимы с текущей версией менеджера патчей RPCS3.
+
+Убедитесь, что все патчи в &quot;%0&quot; имеют правильный формат для версии менеджера патчей %1.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="883"/>
+        <source>Show Patch File</source>
+        <translation>Показать файл патча</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="894"/>
+        <source>Remove Patch</source>
+        <translation>Удалить патч</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="898"/>
+        <source>Remove Patch?</source>
+        <translation>Удалить патч?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="899"/>
+        <source>Do you really want to remove the selected patch?
+This action is immediate and irreversible!</source>
+        <translation>Вы действительно хотите удалить выбранный патч?
+Это действие необратимо!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="910"/>
+        <source>Success</source>
+        <translation>Успешно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="910"/>
+        <source>The patch was successfully removed!</source>
+        <translation>Патч успешно удалён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="916"/>
+        <source>Failure</source>
+        <translation>Сбой</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="916"/>
+        <source>The patch could not be removed!</source>
+        <translation>Не удалось удалить патч!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="930"/>
+        <source>Collapse</source>
+        <translation>Свернуть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="941"/>
+        <source>Expand Children</source>
+        <translation>Развернуть дочерние</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="951"/>
+        <source>Collapse Children</source>
+        <translation>Свернуть дочерние</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="964"/>
+        <source>Expand</source>
+        <translation>Развернуть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="975"/>
+        <source>Expand All</source>
+        <translation>Развернуть всё</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="979"/>
+        <source>Collapse All</source>
+        <translation>Свернуть всё</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1025"/>
+        <source>What do you want to do with the patch file?</source>
+        <translation>Что сделать с файлом патча?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1026"/>
+        <source>Import</source>
+        <translation>Импортировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1027"/>
+        <source>Validate</source>
+        <translation>Проверить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1063"/>
+        <source>
+
+Log:
+%0</source>
+        <translation>
+
+Журнал:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1067"/>
+        <source>Nothing to import</source>
+        <translation>Нечего импортировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1067"/>
+        <source>None of the found %0 patches were imported.%1</source>
+        <translation>Ни один из найденных %0 патчей не был импортирован.%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1072"/>
+        <source>Import successful</source>
+        <translation>Импорт выполнен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1072"/>
+        <source>Imported %0/%1 patches to:
+%2%3</source>
+        <translation>Импортировано %0/%1 патчей в:
+%2%3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1078"/>
+        <source>Import failed</source>
+        <translation>Ошибка импорта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1078"/>
+        <source>The patch file could not be imported.
+
+Log:
+%0</source>
+        <translation>Не удалось импортировать файл патча.
+
+Журнал:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1083"/>
+        <source>Validation successful</source>
+        <translation>Проверка пройдена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1083"/>
+        <source>The patch file passed the validation.</source>
+        <translation>Файл патча прошёл проверку.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1093"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1098"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1310"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1315"/>
+        <source>Validation failed</source>
+        <translation>Проверка не пройдена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1093"/>
+        <source>Errors were found in the patch file.
+
+Log:
+%0</source>
+        <translation>В файле патча обнаружены ошибки.
+
+Журнал:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1097"/>
+        <source>Errors were found in the patch file.</source>
+        <translation>В файле патча обнаружены ошибки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1099"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1316"/>
+        <source>To see the error log, please click &quot;Show Details&quot;.</source>
+        <translation>Для просмотра журнала ошибок нажмите &quot;Подробнее&quot;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1166"/>
+        <source>Downloading latest patches</source>
+        <translation>Загрузка последних патчей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1200"/>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1301"/>
+        <source>Download successful</source>
+        <translation>Загрузка выполнена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1200"/>
+        <source>Your patch file is already up to date.</source>
+        <translation>Файл патча уже актуален.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1215"/>
+        <source>Update patches?</source>
+        <translation>Обновить патчи?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1215"/>
+        <source>New patches are available.
+
+Do you want to update?</source>
+        <translation>Доступны новые патчи.
+
+Хотите обновить?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1301"/>
+        <source>Your patch file is now up to date</source>
+        <translation>Файл патча теперь актуален</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1310"/>
+        <source>Errors were found in the downloaded patch file.
+
+Log:
+%0</source>
+        <translation>В загруженном файле патча обнаружены ошибки.
+
+Журнал:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.cpp" line="1314"/>
+        <source>Errors were found in the downloaded patch file.</source>
+        <translation>В загруженном файле патча обнаружены ошибки.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.h" line="38"/>
+        <source>All titles - Warning: These patches apply to all games!</source>
+        <translation>Все игры — Внимание: эти патчи применяются ко всем играм!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.h" line="39"/>
+        <source>All serials</source>
+        <translation>Все серийные номера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/patch_manager_dialog.h" line="40"/>
+        <source>All versions</source>
+        <translation>Все версии</translation>
+    </message>
+</context>
+<context>
+    <name>pkg_install_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="65"/>
+        <source>DLC</source>
+        <comment>Package type info (DLC)</comment>
+        <translation>DLC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="69"/>
+        <source>Update</source>
+        <comment>Package type info (Update)</comment>
+        <translation>Обновление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="81"/>
+        <source>v.%0</source>
+        <comment>Version info</comment>
+        <translation>v.%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="86"/>
+        <source>No info</source>
+        <comment>Changelog info placeholder</comment>
+        <translation>Нет информации</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="90"/>
+        <source>Changelog:
+
+%0</source>
+        <comment>Changelog info</comment>
+        <translation>Список изменений:
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="96"/>
+        <source>&lt;b&gt;%0&lt;/b&gt; (%1) - %2</source>
+        <comment>Package text</comment>
+        <translation>&lt;b&gt;%0&lt;/b&gt; (%1) - %2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="119"/>
+        <source>Install</source>
+        <translation>Установить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="153"/>
+        <source>Move selected item up</source>
+        <translation>Переместить выбранный элемент вверх</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="158"/>
+        <source>Move selected item down</source>
+        <translation>Переместить выбранный элемент вниз</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="168"/>
+        <source>Do you want to install this package?</source>
+        <translation>Установить этот пакет?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="169"/>
+        <source>You are about to install multiple packages.
+Reorder and/or exclude them if needed, then click &quot;Install&quot; to proceed.</source>
+        <translation>Вы собираетесь установить несколько пакетов.
+При необходимости измените порядок или исключите пакеты, затем нажмите &quot;Установить&quot;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="171"/>
+        <source>Would you like to precompile caches and install shortcuts to the installed software?</source>
+        <translation>Хотите предкомпилировать кэши и установить ярлыки для установленного ПО?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="173"/>
+        <source>Precompile caches</source>
+        <translation>Предкомпилировать кэши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="177"/>
+        <source>Add desktop shortcut(s)</source>
+        <translation>Добавить ярлык(и) на рабочий стол</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="181"/>
+        <source>Add Start menu shortcut(s)</source>
+        <translation>Добавить ярлык(и) в меню «Пуск»</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="183"/>
+        <source>Add dock shortcut(s)</source>
+        <translation>Добавить ярлык(и) в Dock</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="185"/>
+        <source>Add launcher shortcut(s)</source>
+        <translation>Добавить ярлык(и) в меню приложений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="201"/>
+        <source>PKG Installation</source>
+        <translation>Установка PKG</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="226"/>
+        <source>Installation path: %0
+Available disk space: %1%2
+Required disk space: %3</source>
+        <translation>Путь установки: %0
+Доступное место на диске: %1%2
+Требуемое место на диске: %3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/pkg_install_dialog.cpp" line="229"/>
+        <source> - &lt;b&gt;NOT ENOUGH SPACE&lt;/b&gt;</source>
+        <translation> - &lt;b&gt;НЕДОСТАТОЧНО МЕСТА&lt;/b&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>ps_move_tracker_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="20"/>
+        <source>PS Move Tracker Settings</source>
+        <translation>Настройки отслеживания PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="30"/>
+        <source>Preview</source>
+        <translation>Предпросмотр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="49"/>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="273"/>
+        <source>Histogram</source>
+        <translation>Гистограмма</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="100"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="106"/>
+        <source>Min Radius</source>
+        <translation>Мин. радиус</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="122"/>
+        <source>Max Radius</source>
+        <translation>Макс. радиус</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="138"/>
+        <source>PS Move</source>
+        <translation>PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="147"/>
+        <source>Color</source>
+        <translation>Цвет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="186"/>
+        <source>Hue</source>
+        <translation>Оттенок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="205"/>
+        <source>Hue Threshold</source>
+        <translation>Порог оттенка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="224"/>
+        <source>Saturation Threshold</source>
+        <translation>Порог насыщенности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="249"/>
+        <source>Input Format</source>
+        <translation>Формат входных данных</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="261"/>
+        <source>View</source>
+        <translation>Вид</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="285"/>
+        <source>Display</source>
+        <translation>Отображение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="291"/>
+        <source>Filter Small Contours</source>
+        <translation>Фильтровать мелкие контуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="298"/>
+        <source>Freeze Frame</source>
+        <translation>Заморозить кадр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="305"/>
+        <source>Show All Contours</source>
+        <translation>Показывать все контуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="312"/>
+        <source>Draw Contours</source>
+        <translation>Рисовать контуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.ui" line="319"/>
+        <source>Draw Overlays</source>
+        <translation>Рисовать оверлеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="62"/>
+        <source>RGBA</source>
+        <translation>RGBA</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="63"/>
+        <source>RAW8</source>
+        <translation>RAW8</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="76"/>
+        <source>Image</source>
+        <translation>Изображение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="77"/>
+        <source>Grayscale</source>
+        <translation>Оттенки серого</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="78"/>
+        <source>HSV Hue</source>
+        <translation>Оттенок HSV</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="79"/>
+        <source>HSV Saturation</source>
+        <translation>Насыщенность HSV</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="80"/>
+        <source>HSV Value</source>
+        <translation>Яркость HSV</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="81"/>
+        <source>Binary</source>
+        <translation>Бинарный</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="82"/>
+        <source>Contours</source>
+        <translation>Контуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="94"/>
+        <source>Hues</source>
+        <translation>Оттенки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="203"/>
+        <source>PS Move #%0</source>
+        <translation>PS Move #%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="280"/>
+        <source>Color: R=%0, G=%1, B=%2</source>
+        <translation>Цвет: R=%0, G=%1, B=%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="320"/>
+        <source>Hue: %0</source>
+        <translation>Оттенок: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="340"/>
+        <source>Hue Threshold: %0</source>
+        <translation>Порог оттенка: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="351"/>
+        <source>Saturation Threshold: %0</source>
+        <translation>Порог насыщенности: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="361"/>
+        <source>Min Radius: %0 %</source>
+        <translation>Мин. радиус: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/ps_move_tracker_dialog.cpp" line="371"/>
+        <source>Max Radius: %0 %</source>
+        <translation>Макс. радиус: %0 %</translation>
+    </message>
+</context>
+<context>
+    <name>raw_mouse_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="22"/>
+        <source>Configure Raw Mouse Handler</source>
+        <translation>Настройка обработчика прямого ввода мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="48"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="48"/>
+        <source>Reset settings of all players?</source>
+        <translation>Сбросить настройки всех игроков?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="107"/>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="520"/>
+        <source>[ Waiting %1 ]</source>
+        <translation>[ Ожидание %1 ]</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="153"/>
+        <source>Disabled</source>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="222"/>
+        <source>Device</source>
+        <translation>Устройство</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="279"/>
+        <source>Mouse Acceleration</source>
+        <translation>Ускорение мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/raw_mouse_settings_dialog.cpp" line="295"/>
+        <source>Player %0</source>
+        <translation>Игрок %0</translation>
+    </message>
+</context>
+<context>
+    <name>recvmessage_dialog_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="43"/>
+        <source>Choose message:</source>
+        <translation>Выбрать сообщение:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="54"/>
+        <source>Accept</source>
+        <translation>Принять</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="55"/>
+        <source>Deny</source>
+        <translation>Отклонить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="56"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="73"/>
+        <source>Error receiving a message!</source>
+        <translation>Ошибка при получении сообщения!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/recvmessage_dialog_frame.cpp" line="73"/>
+        <source>You must select a message!</source>
+        <translation>Необходимо выбрать сообщение!</translation>
+    </message>
+</context>
+<context>
+    <name>register_editor_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="166"/>
+        <source>Error parsing register value!</source>
+        <translation>Ошибка разбора значения регистра!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="195"/>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="217"/>
+        <source>Lose reservation on OK</source>
+        <translation>Потеря резервирования при нажатии OK</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="195"/>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="217"/>
+        <source>Reservation is inactive</source>
+        <translation>Резервирование неактивно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="423"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/register_editor_dialog.cpp" line="423"/>
+        <source>This value could not be converted.
+No changes were made.</source>
+        <translation>Это значение не удалось преобразовать.
+Изменения не применены.</translation>
+    </message>
+</context>
+<context>
+    <name>render_creator</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/render_creator.cpp" line="78"/>
+        <source>Vulkan Check Timeout</source>
+        <translation>Превышено время ожидания Vulkan</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/render_creator.cpp" line="79"/>
+        <source>Querying for Vulkan-compatible devices is taking too long. This is usually caused by malfunctioning graphics drivers, reinstalling them could fix the issue.
+
+Selecting ignore starts the emulator without Vulkan support.</source>
+        <translation>Поиск устройств с поддержкой Vulkan занимает слишком много времени. Обычно это вызвано неисправными драйверами видеокарты — переустановка может помочь.
+
+При выборе «Игнорировать» эмулятор запустится без поддержки Vulkan.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/render_creator.cpp" line="110"/>
+        <source>Warning</source>
+        <translation>Предупреждение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/render_creator.cpp" line="111"/>
+        <source>Vulkan is not supported on this Mac.
+No graphics will be rendered.</source>
+        <translation>Vulkan не поддерживается на этом Mac.
+Графика не будет отображаться.</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_account_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="151"/>
+        <source>RPCN: Account</source>
+        <translation>RPCN: Аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="156"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="160"/>
+        <source>Server:</source>
+        <translation>Сервер:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="169"/>
+        <source>Add</source>
+        <translation>Добавить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="170"/>
+        <source>Del</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="181"/>
+        <source>Account:</source>
+        <translation>Аккаунт:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="183"/>
+        <source>Create Account</source>
+        <translation>Создать аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="184"/>
+        <source>Edit Account</source>
+        <translation>Редактировать аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="185"/>
+        <source>Test Account</source>
+        <translation>Проверить аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="194"/>
+        <source>Current ID: %0</source>
+        <translation>Текущий ID: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="239"/>
+        <source>Existing Server</source>
+        <translation>Сервер уже существует</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="239"/>
+        <source>You already have a server with this description &amp; hostname in the list.</source>
+        <translation>Сервер с таким описанием и адресом уже есть в списке.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="265"/>
+        <source>Please enter your username.
+
+Note that these restrictions apply:
+- Username must be between 3 and 16 characters
+- Username can only contain a-z A-Z 0-9 &apos;-&apos; &apos;_&apos;
+- Username is case sensitive
+</source>
+        <translation>Введите имя пользователя.
+
+Обратите внимание на ограничения:
+- Имя пользователя должно содержать от 3 до 16 символов
+- Имя пользователя может включать только a-z A-Z 0-9 &apos;-&apos; &apos;_&apos;
+- Регистр имени пользователя учитывается
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="276"/>
+        <source>Please choose your password:
+
+</source>
+        <translation>Выберите пароль:
+
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="283"/>
+        <source>An email address is required, please note:
+- A valid email is needed to receive the token that validates your account.
+- Your email won&apos;t be used for anything beyond sending you this token or the password reset token.
+
+</source>
+        <translation>Требуется адрес электронной почты, обратите внимание:
+- Действительный email необходим для получения токена подтверждения аккаунта.
+- Ваш email не будет использован ни для каких целей, кроме отправки этого токена или токена сброса пароля.
+
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="292"/>
+        <source>RPCN: Account Creation</source>
+        <translation>RPCN: Создание аккаунта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="292"/>
+        <source>You are about to create an account with:
+-Username:%0
+-Email:%1
+
+Is this correct?</source>
+        <translation>Вы собираетесь создать аккаунт:
+-Имя пользователя:%0
+-Email:%1
+
+Всё верно?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="307"/>
+        <source>An account with that username already exists!</source>
+        <translation>Аккаунт с таким именем пользователя уже существует!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="308"/>
+        <source>This email provider is banned!</source>
+        <translation>Данный почтовый провайдер заблокирован!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="309"/>
+        <source>An account with that email already exists!</source>
+        <translation>Аккаунт с таким email уже существует!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="310"/>
+        <source>Unknown creation error!</source>
+        <translation>Неизвестная ошибка при создании!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="311"/>
+        <source>Unknown error</source>
+        <translation>Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="313"/>
+        <source>Error Creating Account!</source>
+        <translation>Ошибка создания аккаунта!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="313"/>
+        <source>Failed to create the account:
+%0</source>
+        <translation>Не удалось создать аккаунт:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="322"/>
+        <source>Your account has been created successfully!
+Your account authentification was saved.
+Now all you need is to enter the token that was sent to your email.
+You can skip this step by leaving it empty and entering it later in the Edit Account section too.
+</source>
+        <translation>Ваш аккаунт успешно создан!
+Данные авторизации аккаунта сохранены.
+Теперь вам нужно ввести токен, отправленный на ваш email.
+Вы можете пропустить этот шаг, оставив поле пустым, и ввести токен позже в разделе «Редактировать аккаунт».
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="354"/>
+        <source>Failed to authentify to RPCN:
+%0</source>
+        <translation>Не удалось авторизоваться в RPCN:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="355"/>
+        <source>Error authentifying to RPCN!</source>
+        <translation>Ошибка авторизации в RPCN!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="359"/>
+        <source>RPCN Account Valid!</source>
+        <translation>Аккаунт RPCN действителен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="359"/>
+        <source>Your account is valid!</source>
+        <translation>Ваш аккаунт действителен!</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_account_edit_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="732"/>
+        <source>RPCN: Edit Account</source>
+        <translation>RPCN: Редактировать аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="742"/>
+        <source>Username:</source>
+        <translation>Имя пользователя:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="746"/>
+        <source>Password:</source>
+        <translation>Пароль:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="747"/>
+        <source>Set Password</source>
+        <translation>Установить пароль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="748"/>
+        <source>Token:</source>
+        <translation>Токен:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="752"/>
+        <source>Resend Token</source>
+        <translation>Повторно отправить токен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="753"/>
+        <source>Change Password</source>
+        <translation>Изменить пароль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="754"/>
+        <source>Delete Account</source>
+        <translation>Удалить аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="755"/>
+        <source>Save</source>
+        <translation>Сохранить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="781"/>
+        <source>Please enter your password:</source>
+        <translation>Введите ваш пароль:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="791"/>
+        <source>RPCN Password Saved</source>
+        <translation>Пароль RPCN сохранён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="791"/>
+        <source>Your password was saved successfully!</source>
+        <translation>Ваш пароль успешно сохранён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="816"/>
+        <source>Missing Input</source>
+        <translation>Не введены данные</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="816"/>
+        <source>You need to enter a username and a password!</source>
+        <translation>Необходимо ввести имя пользователя и пароль!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="822"/>
+        <source>Invalid Username</source>
+        <translation>Неверное имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="822"/>
+        <source>Username must be between 3 and 16 characters and can only contain &apos;-&apos;, &apos;_&apos; or alphanumeric characters.</source>
+        <translation>Имя пользователя должно содержать от 3 до 16 символов и может включать только &apos;-&apos;, &apos;_&apos; или буквенно-цифровые символы.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="828"/>
+        <source>Invalid Token</source>
+        <translation>Неверный токен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="828"/>
+        <source>The token you have received should be 16 characters long and contain only 0-9 A-F.</source>
+        <translation>Полученный токен должен содержать 16 символов и включать только 0-9 и A-F.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="858"/>
+        <source>The server has no email verification and doesn&apos;t need a token!</source>
+        <translation>Сервер не использует проверку email и не требует токен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="859"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="905"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="947"/>
+        <source>A database related error happened on the server!</source>
+        <translation>На сервере произошла ошибка базы данных!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="860"/>
+        <source>You can only ask for a token mail once every 24 hours!</source>
+        <translation>Запросить письмо с токеном можно только раз в 24 часа!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="861"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="907"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="949"/>
+        <source>The mail couldn&apos;t be sent successfully!</source>
+        <translation>Не удалось отправить письмо!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="862"/>
+        <source>The username/password pair is invalid!</source>
+        <translation>Неверная пара имя пользователя/пароль!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="863"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="951"/>
+        <source>Unknown error</source>
+        <translation>Неизвестная ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="865"/>
+        <source>Error Sending Token!</source>
+        <translation>Ошибка отправки токена!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="865"/>
+        <source>Failed to send the token:
+%0</source>
+        <translation>Не удалось отправить токен:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="869"/>
+        <source>Token Sent!</source>
+        <translation>Токен отправлен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="869"/>
+        <source>Your token was successfully resent to the email associated with your account!</source>
+        <translation>Токен успешно повторно отправлен на email, привязанный к вашему аккаунту!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="874"/>
+        <source>Please confirm your username:</source>
+        <translation>Подтвердите имя пользователя:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="881"/>
+        <source>RPCN: Change Password</source>
+        <translation>RPCN: Изменение пароля</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="881"/>
+        <source>Do you already have a reset password token?
+Note that the reset password token is different from the email verification token.</source>
+        <translation>Есть ли у вас токен для сброса пароля?
+Обратите внимание: токен сброса пароля отличается от токена подтверждения email.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="886"/>
+        <source>Please enter the email you used to create the account:</source>
+        <translation>Введите email, использованный при создании аккаунта:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="904"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="946"/>
+        <source>The server has no email verification and doesn&apos;t support password changes!</source>
+        <translation>Сервер не использует проверку email и не поддерживает изменение пароля!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="906"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="948"/>
+        <source>You can only ask for a reset password token once every 24 hours!</source>
+        <translation>Запросить токен сброса пароля можно только раз в 24 часа!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="908"/>
+        <source>The username/email pair is invalid!</source>
+        <translation>Неверная пара имя пользователя/email!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="909"/>
+        <source>Unknown error!</source>
+        <translation>Неизвестная ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="911"/>
+        <source>Error Sending Password Reset Token!</source>
+        <translation>Ошибка отправки токена сброса пароля!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="911"/>
+        <source>Failed to send the password reset token:
+%0</source>
+        <translation>Не удалось отправить токен сброса пароля:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="915"/>
+        <source>Password Reset Token Sent!</source>
+        <translation>Токен сброса пароля отправлен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="915"/>
+        <source>The reset password token has successfully been sent!</source>
+        <translation>Токен сброса пароля успешно отправлен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="921"/>
+        <source>Please enter the password reset token you received:</source>
+        <translation>Введите полученный токен сброса пароля:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="928"/>
+        <source>Please enter your new password:</source>
+        <translation>Введите новый пароль:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="950"/>
+        <source>The username/token pair is invalid!</source>
+        <translation>Неверная пара имя пользователя/токен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="953"/>
+        <source>Error Sending Password Reset Token</source>
+        <translation>Ошибка отправки токена сброса пароля</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="953"/>
+        <source>Failed to change the password:
+%0</source>
+        <translation>Не удалось изменить пароль:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="959"/>
+        <source>Password Successfully Changed!</source>
+        <translation>Пароль успешно изменён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="959"/>
+        <source>Your password has been successfully changed!</source>
+        <translation>Ваш пароль успешно изменён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="972"/>
+        <source>Account Not Configured</source>
+        <translation>Аккаунт не настроен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="972"/>
+        <source>Please configure your account in the settings before deleting it.</source>
+        <translation>Пожалуйста, настройте аккаунт в настройках перед его удалением.</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_add_server_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="393"/>
+        <source>RPCN: Add Server</source>
+        <translation>RPCN: Добавить сервер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="399"/>
+        <source>Description:</source>
+        <translation>Описание:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="401"/>
+        <source>Host:</source>
+        <translation>Адрес:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="420"/>
+        <source>Missing Description!</source>
+        <translation>Описание не указано!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="420"/>
+        <source>You must enter a description!</source>
+        <translation>Необходимо ввести описание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="425"/>
+        <source>Missing Hostname!</source>
+        <translation>Адрес не указан!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="425"/>
+        <source>You must enter a hostname for the server!</source>
+        <translation>Необходимо ввести адрес сервера!</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_ask_email_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="553"/>
+        <source>RPCN: Email</source>
+        <translation>RPCN: Email</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="563"/>
+        <source>Enter your email:</source>
+        <translation>Введите ваш email:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="565"/>
+        <source>Enter your email a second time:</source>
+        <translation>Введите email ещё раз:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="586"/>
+        <source>Wrong Input</source>
+        <translation>Неверный ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="586"/>
+        <source>The two emails you entered don&apos;t match!</source>
+        <translation>Введённые email-адреса не совпадают!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="592"/>
+        <source>Missing Email</source>
+        <translation>Email не указан</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="592"/>
+        <source>You need to enter an email!</source>
+        <translation>Необходимо ввести email!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="599"/>
+        <source>Invalid Email</source>
+        <translation>Неверный email</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="599"/>
+        <source>You need to enter a valid email!</source>
+        <translation>Необходимо ввести действительный email!</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_ask_password_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="494"/>
+        <source>RPCN: Password</source>
+        <translation>RPCN: Пароль</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="504"/>
+        <source>Enter your password:</source>
+        <translation>Введите ваш пароль:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="507"/>
+        <source>Enter your password a second time:</source>
+        <translation>Введите пароль ещё раз:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="529"/>
+        <source>Wrong Input</source>
+        <translation>Неверный ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="529"/>
+        <source>The two passwords you entered don&apos;t match!</source>
+        <translation>Введённые пароли не совпадают!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="535"/>
+        <source>Missing Password</source>
+        <translation>Пароль не указан</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="535"/>
+        <source>You need to enter a password!</source>
+        <translation>Необходимо ввести пароль!</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_ask_token_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="617"/>
+        <source>RPCN: Username</source>
+        <translation>RPCN: Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="624"/>
+        <source>Token:</source>
+        <translation>Токен:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="647"/>
+        <source>Invalid Token</source>
+        <translation>Неверный токен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="647"/>
+        <source>The token appears to be invalid:
+-Token should be 16 characters long
+-Token should only contain 0-9 and A-F</source>
+        <translation>Токен недействителен:
+-Токен должен содержать 16 символов
+-Токен может включать только 0-9 и A-F</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_ask_username_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="443"/>
+        <source>RPCN: Username</source>
+        <translation>RPCN: Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="450"/>
+        <source>Username:</source>
+        <translation>Имя пользователя:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="472"/>
+        <source>Missing Username!</source>
+        <translation>Имя пользователя не указано!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="472"/>
+        <source>You must enter a username!</source>
+        <translation>Необходимо ввести имя пользователя!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="477"/>
+        <source>Invalid Username!</source>
+        <translation>Неверное имя пользователя!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="477"/>
+        <source>Please enter a valid username!</source>
+        <translation>Введите действительное имя пользователя!</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_confirm_delete_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="670"/>
+        <source>Confirm Account Deletion</source>
+        <translation>Подтверждение удаления аккаунта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="675"/>
+        <source>Are you sure you want to delete RPCN account &quot;%1&quot;?
+
+Important:
+Deleting your account will blacklist your username and email for 3 months.
+To confirm, type your username below and click &quot;Yes&quot;.
+</source>
+        <translation>Вы уверены, что хотите удалить аккаунт RPCN &quot;%1&quot;?
+
+Важно:
+Удаление аккаунта занесёт ваше имя пользователя и email в чёрный список на 3 месяца.
+Для подтверждения введите имя пользователя ниже и нажмите &quot;Да&quot;.
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="682"/>
+        <source>Type your username to confirm</source>
+        <translation>Введите имя пользователя для подтверждения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="684"/>
+        <source>Yes</source>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="686"/>
+        <source>No</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="714"/>
+        <source>Invalid login or password.</source>
+        <translation>Неверный логин или пароль.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="715"/>
+        <source>Cannot delete a currently logged-in account.</source>
+        <translation>Нельзя удалить аккаунт, под которым выполнен вход.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="716"/>
+        <source>An unknown error occurred.</source>
+        <translation>Произошла неизвестная ошибка.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="718"/>
+        <source>Deletion Failed</source>
+        <translation>Ошибка удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="718"/>
+        <source>Failed to delete the account:
+%1</source>
+        <translation>Не удалось удалить аккаунт:
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="723"/>
+        <source>Account Deleted</source>
+        <translation>Аккаунт удалён</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="723"/>
+        <source>Your account has been successfully deleted.</source>
+        <translation>Ваш аккаунт успешно удалён.</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_friends_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1074"/>
+        <source>RPCN: Friends - Logged in as %0</source>
+        <translation>RPCN: Друзья — вошли как %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1078"/>
+        <source>RPCN: Friends - %0 (Not logged in)</source>
+        <translation>RPCN: Друзья — %0 (не авторизован)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1082"/>
+        <source>RPCN: Friends</source>
+        <translation>RPCN: Друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1093"/>
+        <source>Friends</source>
+        <translation>Друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1098"/>
+        <source>Add Friend</source>
+        <translation>Добавить друга</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1103"/>
+        <source>Friend Requests</source>
+        <translation>Запросы в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1113"/>
+        <source>Blocked Users</source>
+        <translation>Заблокированные пользователи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1120"/>
+        <source>Recent Players</source>
+        <translation>Недавние игроки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1140"/>
+        <source>Failed to authentify to RPCN:
+%0</source>
+        <translation>Не удалось авторизоваться в RPCN:
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1141"/>
+        <source>Error authentifying to RPCN!</source>
+        <translation>Ошибка авторизации в RPCN!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1206"/>
+        <source>&amp;Remove Friend</source>
+        <translation>&amp;Удалить друга</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1212"/>
+        <source>Error removing a friend!</source>
+        <translation>Ошибка при удалении друга!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1212"/>
+        <source>An error occurred while trying to remove a friend!</source>
+        <translation>При удалении друга произошла ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1216"/>
+        <source>Friend removed!</source>
+        <translation>Друг удалён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1216"/>
+        <source>You&apos;ve successfully removed a friend!</source>
+        <translation>Вы успешно удалили друга!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1239"/>
+        <source>&amp;Cancel Request</source>
+        <translation>&amp;Отменить запрос</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1245"/>
+        <source>Error cancelling friend request!</source>
+        <translation>Ошибка при отмене запроса в друзья!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1245"/>
+        <source>An error occurred while trying to cancel friend request!</source>
+        <translation>При отмене запроса в друзья произошла ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1249"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1280"/>
+        <source>Friend request cancelled!</source>
+        <translation>Запрос в друзья отменён!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1249"/>
+        <source>You&apos;ve successfully cancelled the friend request!</source>
+        <translation>Вы успешно отменили запрос в друзья!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1260"/>
+        <source>&amp;Accept Request</source>
+        <translation>&amp;Принять запрос</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1261"/>
+        <source>&amp;Reject Request</source>
+        <translation>&amp;Отклонить запрос</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1267"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1341"/>
+        <source>Friend added!</source>
+        <translation>Друг добавлен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1267"/>
+        <source>You&apos;ve successfully added a friend!</source>
+        <translation>Вы успешно добавили друга!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1276"/>
+        <source>Error rejecting friend request!</source>
+        <translation>Ошибка при отклонении запроса в друзья!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1276"/>
+        <source>An error occurred while trying to reject the friend request!</source>
+        <translation>При отклонении запроса в друзья произошла ошибка!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1280"/>
+        <source>You&apos;ve successfully rejected the friend request!</source>
+        <translation>Вы успешно отклонили запрос в друзья!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1300"/>
+        <source>&amp;Send Friend Request</source>
+        <translation>&amp;Отправить запрос в друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1322"/>
+        <source>Add a friend</source>
+        <translation>Добавить друга</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1322"/>
+        <source>Friend&apos;s username:</source>
+        <translation>Имя пользователя друга:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1335"/>
+        <source>Error validating username!</source>
+        <translation>Ошибка проверки имени пользователя!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1335"/>
+        <source>The username you entered is invalid!</source>
+        <translation>Введённое имя пользователя недействительно!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1341"/>
+        <source>Friend was successfully added!</source>
+        <translation>Друг успешно добавлен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1366"/>
+        <source>The specified username does not exist.</source>
+        <translation>Указанное имя пользователя не существует.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1367"/>
+        <source>You cannot add yourself as a friend.</source>
+        <translation>Нельзя добавить себя в друзья.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1368"/>
+        <source>You or the other user have the other blocked.</source>
+        <translation>Вы или другой пользователь заблокированы друг у друга.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1369"/>
+        <source>You are already friends with this user.</source>
+        <translation>Вы уже являетесь друзьями с этим пользователем.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1370"/>
+        <source>A database error occurred. Please try again later.</source>
+        <translation>Произошла ошибка базы данных. Пожалуйста, попробуйте позже.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1371"/>
+        <source>An unexpected error occurred.</source>
+        <translation>Произошла непредвиденная ошибка.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1377"/>
+        <source>Failed to send the friend request.</source>
+        <translation>Не удалось отправить запрос в друзья.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="1382"/>
+        <source>Friend Request Failed</source>
+        <translation>Ошибка запроса в друзья</translation>
+    </message>
+</context>
+<context>
+    <name>rpcn_settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="102"/>
+        <source>RPCN - %0</source>
+        <translation>RPCN — %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="106"/>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="115"/>
+        <source>RPCN</source>
+        <translation>RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="118"/>
+        <source>Account</source>
+        <translation>Аккаунт</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="119"/>
+        <source>Friends</source>
+        <translation>Друзья</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="132"/>
+        <source>Error: Emulation Running</source>
+        <translation>Ошибка: эмуляция запущена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rpcn_settings_dialog.cpp" line="132"/>
+        <source>You need to stop the emulator before editing RPCN account information!</source>
+        <translation>Необходимо остановить эмулятор перед изменением информации аккаунта RPCN!</translation>
+    </message>
+</context>
+<context>
+    <name>rsx_debugger</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="46"/>
+        <source>RSX Debugger</source>
+        <translation>Отладчик RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="58"/>
+        <source>Frame</source>
+        <translation>Кадр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="59"/>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="136"/>
+        <source>Texture</source>
+        <translation>Текстура</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="60"/>
+        <source>Draw</source>
+        <translation>Отрисовка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="61"/>
+        <source>Primitive</source>
+        <translation>Примитив</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="62"/>
+        <source>Command</source>
+        <translation>Команда</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="76"/>
+        <source>Break on:</source>
+        <translation>Прервать на:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="112"/>
+        <source>Captured Frame</source>
+        <translation>Захваченный кадр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="113"/>
+        <source>Captured Draw Calls</source>
+        <translation>Захваченные вызовы отрисовки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="115"/>
+        <source>Column</source>
+        <translation>Колонка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="118"/>
+        <source>Draw calls</source>
+        <translation>Вызовы отрисовки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="130"/>
+        <source>Color Buffer A</source>
+        <translation>Буфер цвета A</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="131"/>
+        <source>Color Buffer B</source>
+        <translation>Буфер цвета B</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="132"/>
+        <source>Color Buffer C</source>
+        <translation>Буфер цвета C</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="133"/>
+        <source>Color Buffer D</source>
+        <translation>Буфер цвета D</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="134"/>
+        <source>Depth Buffer</source>
+        <translation>Буфер глубины</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="135"/>
+        <source>Stencil Buffer</source>
+        <translation>Буфер трафарета</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="149"/>
+        <source>Texture Index or Address / Format Override</source>
+        <translation>Индекс или адрес текстуры / замена формата</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="221"/>
+        <source>RTTs and DS</source>
+        <translation>RTT и DS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="222"/>
+        <source>Vertex Program</source>
+        <translation>Вершинная программа</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="223"/>
+        <source>Fragment Program</source>
+        <translation>Фрагментная программа</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.cpp" line="224"/>
+        <source>Index Buffer</source>
+        <translation>Индексный буфер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/rsx_debugger.h" line="54"/>
+        <source> Enabled Textures Indices: </source>
+        <translation> Индексы активных текстур: </translation>
+    </message>
+</context>
+<context>
+    <name>save_data_info_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="12"/>
+        <source>Save Data Information</source>
+        <translation>Информация о сохранении</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="21"/>
+        <source>Name</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="21"/>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="71"/>
+        <source>Detail</source>
+        <translation>Детали</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="24"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Закрыть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="62"/>
+        <source>User ID</source>
+        <translation>ID пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="65"/>
+        <source>Title</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="68"/>
+        <source>Subtitle</source>
+        <translation>Подзаголовок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_info_dialog.cpp" line="80"/>
+        <source>Icon</source>
+        <translation>Иконка</translation>
+    </message>
+</context>
+<context>
+    <name>save_data_list_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="25"/>
+        <source>Save Data Interface (Delete)</source>
+        <translation>Интерфейс сохранений (Удаление)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="29"/>
+        <source>Save Data Interface (Load)</source>
+        <translation>Интерфейс сохранений (Загрузка)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="33"/>
+        <source>Save Data Interface (Save)</source>
+        <translation>Интерфейс сохранений (Сохранение)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="49"/>
+        <source>Title</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="49"/>
+        <source>Subtitle</source>
+        <translation>Подзаголовок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="49"/>
+        <source>Save ID</source>
+        <translation>ID сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="49"/>
+        <source>Entry Notes</source>
+        <translation>Заметки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="56"/>
+        <source>&amp;Select Entry</source>
+        <translation>&amp;Выбрать запись</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="68"/>
+        <source>Save New Entry</source>
+        <translation>Сохранить новую запись</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="79"/>
+        <source>&amp;Cancel</source>
+        <translation>&amp;Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="127"/>
+        <source>Currently Selected: None</source>
+        <translation>Выбрано: Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_data_list_dialog.cpp" line="132"/>
+        <source>Currently Selected: </source>
+        <translation>Выбрано: </translation>
+    </message>
+</context>
+<context>
+    <name>save_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="59"/>
+        <source>Save Manager</source>
+        <translation>Менеджер сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="86"/>
+        <source>Icon size:</source>
+        <translation>Размер иконок:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="91"/>
+        <source>Search:</source>
+        <translation>Поиск:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="93"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Закрыть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="99"/>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="668"/>
+        <source>Select an item to view details</source>
+        <translation>Выберите элемент для просмотра деталей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="109"/>
+        <source>Delete Selection</source>
+        <translation>Удалить выбранное</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="111"/>
+        <source>View Folder</source>
+        <translation>Открыть папку</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="208"/>
+        <source>Icon</source>
+        <translation>Иконка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="209"/>
+        <source>Title &amp; Subtitle</source>
+        <translation>Название и подзаголовок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="210"/>
+        <source>Last Modified</source>
+        <translation>Последнее изменение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="211"/>
+        <source>Save ID</source>
+        <translation>ID сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="212"/>
+        <source>Notes</source>
+        <translation>Заметки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="246"/>
+        <source>Loading save data</source>
+        <translation>Загрузка сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="246"/>
+        <source>Loading save data, please wait...</source>
+        <translation>Загрузка сохранений, пожалуйста, подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="246"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="561"/>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="585"/>
+        <source>Delete Confirmation</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="561"/>
+        <source>Are you sure you want to delete:
+%1?</source>
+        <translation>Вы уверены, что хотите удалить:
+%1?</translation>
+    </message>
+    <message numerus="yes">
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="585"/>
+        <source>Are you sure you want to delete these %n items?</source>
+        <translation>
+            <numerusform>Вы уверены, что хотите удалить %n элемент?</numerusform>
+            <numerusform>Вы уверены, что хотите удалить %n элемента?</numerusform>
+            <numerusform>Вы уверены, что хотите удалить %n элементов?</numerusform>
+        </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="608"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="609"/>
+        <source>&amp;Open Save Directory</source>
+        <translation>&amp;Открыть папку сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="663"/>
+        <source>%1 items selected</source>
+        <translation>Выбрано элементов: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="694"/>
+        <source>Last modified: %1</source>
+        <translation>Последнее изменение: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="695"/>
+        <source>Details:
+</source>
+        <translation>Детали:
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/save_manager_dialog.cpp" line="696"/>
+        <source>Note:
+</source>
+        <translation>Заметка:
+</translation>
+    </message>
+</context>
+<context>
+    <name>savestate_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="35"/>
+        <source>Savestate Manager</source>
+        <translation>Менеджер сохранений состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="120"/>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="156"/>
+        <source>Game Icon Size: %0x%1</source>
+        <translation>Размер иконки игры: %0x%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="127"/>
+        <source>Choose Game</source>
+        <translation>Выбрать игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="132"/>
+        <source>Icon Options</source>
+        <translation>Параметры иконок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="232"/>
+        <source>Name</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="233"/>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="779"/>
+        <source>Compatible</source>
+        <translation>Совместимые</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="234"/>
+        <source>Created</source>
+        <translation>Создано</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="235"/>
+        <source>Path</source>
+        <translation>Путь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="245"/>
+        <source>Show Names</source>
+        <translation>Показывать названия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="246"/>
+        <source>Show Compatible</source>
+        <translation>Показывать совместимые</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="247"/>
+        <source>Show Created</source>
+        <translation>Показывать дату создания</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="248"/>
+        <source>Show Paths</source>
+        <translation>Показывать пути</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="258"/>
+        <source>Icon</source>
+        <translation>Иконка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="259"/>
+        <source>Game</source>
+        <translation>Игра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="260"/>
+        <source>Savestates</source>
+        <translation>Сохранения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="270"/>
+        <source>Show Icons</source>
+        <translation>Показывать иконки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="271"/>
+        <source>Show Games</source>
+        <translation>Показывать игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="272"/>
+        <source>Show Savestates</source>
+        <translation>Показывать сохранения состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="490"/>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="551"/>
+        <source>&amp;Open Savestate Directory</source>
+        <translation>&amp;Открыть папку сохранений состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="491"/>
+        <source>&amp;Boot Savestate</source>
+        <translation>&amp;Загрузить сохранение состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="492"/>
+        <source>&amp;Delete Savestate</source>
+        <translation>&amp;Удалить сохранение состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="517"/>
+        <source>Confirm Deletion</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="517"/>
+        <source>Delete savestate &apos;%0&apos;?</source>
+        <translation>Удалить сохранение состояния &apos;%0&apos;?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="528"/>
+        <source>Deletion Failed!</source>
+        <translation>Ошибка удаления!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="528"/>
+        <source>Failed to delete savestate &apos;%0&apos;!</source>
+        <translation>Не удалось удалить сохранение состояния &apos;%0&apos;!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="550"/>
+        <source>&amp;Remove All Savestates</source>
+        <translation>&amp;Удалить все сохранения состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="560"/>
+        <source>Delete Confirmation</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="560"/>
+        <source>Are you sure you want to delete the savestates for:
+%0?</source>
+        <translation>Вы уверены, что хотите удалить сохранения состояния для:
+%0?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="577"/>
+        <source>&amp;Copy Name</source>
+        <translation>&amp;Копировать название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="647"/>
+        <source>Loading savestates</source>
+        <translation>Загрузка сохранений состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="647"/>
+        <source>Loading savestates, please wait...</source>
+        <translation>Загрузка сохранений состояния, пожалуйста, подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="647"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/savestate_manager_dialog.cpp" line="779"/>
+        <source>Not compatible</source>
+        <translation>Несовместимые</translation>
+    </message>
+</context>
+<context>
+    <name>screenshot_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_manager_dialog.cpp" line="21"/>
+        <source>Screenshots</source>
+        <translation>Скриншоты</translation>
+    </message>
+</context>
+<context>
+    <name>screenshot_preview</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="21"/>
+        <source>Screenshot Viewer</source>
+        <translation>Просмотр скриншотов</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="35"/>
+        <source>&amp;Copy</source>
+        <translation>&amp;Копировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="37"/>
+        <source>&amp;Open file location</source>
+        <translation>&amp;Открыть расположение файла</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="40"/>
+        <source>To &amp;Normal Size</source>
+        <translation>&amp;Нормальный размер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="43"/>
+        <source>&amp;Stretch to size</source>
+        <translation>&amp;Растянуть по размеру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/screenshot_preview.cpp" line="48"/>
+        <source>E&amp;xit</source>
+        <translation>В&amp;ыход</translation>
+    </message>
+</context>
+<context>
+    <name>sendmessage_dialog_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sendmessage_dialog_frame.cpp" line="41"/>
+        <source>Choose friend to message:</source>
+        <translation>Выберите друга для отправки сообщения:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sendmessage_dialog_frame.cpp" line="52"/>
+        <source>Ok</source>
+        <translation>ОК</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sendmessage_dialog_frame.cpp" line="53"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sendmessage_dialog_frame.cpp" line="71"/>
+        <source>Error sending a message!</source>
+        <translation>Ошибка отправки сообщения!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sendmessage_dialog_frame.cpp" line="71"/>
+        <source>You must select a friend!</source>
+        <translation>Необходимо выбрать друга!</translation>
+    </message>
+</context>
+<context>
+    <name>settings_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="23"/>
+        <source>Settings</source>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="61"/>
+        <source>CPU</source>
+        <translation>CPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="71"/>
+        <source>PPU Decoder</source>
+        <translation>Декодер PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="94"/>
+        <source>SPU Decoder</source>
+        <translation>Декодер SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="157"/>
+        <source>SPU XFloat Accuracy</source>
+        <translation>Точность XFloat SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="175"/>
+        <source>SPU Block Size</source>
+        <translation>Размер блока SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="187"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="907"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1771"/>
+        <source>Additional Settings</source>
+        <translation>Дополнительные настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="193"/>
+        <source>Enable SPU loop detection</source>
+        <translation>Включить обнаружение циклов SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="209"/>
+        <source>Max Power Saving CPU-preemptions</source>
+        <translation>Максимальное энергосбережение CPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="230"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="645"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="782"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="813"/>
+        <source>0</source>
+        <translation>0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="240"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="655"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="716"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="823"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2574"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2649"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2810"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2853"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3395"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4521"/>
+        <source>Reset</source>
+        <translation>Сбросить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="278"/>
+        <source>Preferred SPU Threads</source>
+        <translation>Предпочтительное количество потоков SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="296"/>
+        <source>Thread Scheduler</source>
+        <translation>Планировщик потоков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="344"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="997"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1545"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1849"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2157"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2369"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2905"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3745"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4172"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4643"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="350"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1003"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1551"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1855"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2163"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2375"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2911"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3751"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4178"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4649"/>
+        <source>Point your mouse at an option to display a description in here.
+
+
+</source>
+        <translation>Наведите мышь на параметр, чтобы увидеть его описание.
+
+
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="373"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2671"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4212"/>
+        <source>GPU</source>
+        <translation>GPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="383"/>
+        <source>Renderer</source>
+        <translation>Рендерер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="395"/>
+        <source>Graphics Device</source>
+        <translation>Графическое устройство</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="422"/>
+        <source>Aspect Ratio</source>
+        <translation>Соотношение сторон</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="434"/>
+        <source>Framelimit</source>
+        <translation>Ограничение частоты кадров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="464"/>
+        <source>Anisotropic Filter</source>
+        <translation>Анизотропная фильтрация</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="476"/>
+        <source>Anti-Aliasing</source>
+        <translation>Сглаживание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="506"/>
+        <source>ZCULL Accuracy</source>
+        <translation>Точность ZCULL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="518"/>
+        <source>Shader Quality</source>
+        <translation>Качество шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="533"/>
+        <source>3D</source>
+        <translation>3D</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="539"/>
+        <source>Enable 3D Support</source>
+        <translation>Включить поддержку 3D</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="572"/>
+        <source>Default Resolution</source>
+        <translation>Разрешение по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="592"/>
+        <source>Resolution Scale (Disable Strict Mode)</source>
+        <translation>Масштаб разрешения (отключить строгий режим)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="616"/>
+        <source>25</source>
+        <translation>25</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="633"/>
+        <source>800</source>
+        <translation>800</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="667"/>
+        <source>Resolution Scale Threshold</source>
+        <translation>Порог масштаба разрешения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="678"/>
+        <source>1</source>
+        <translation>1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="695"/>
+        <source>1024</source>
+        <translation>1024</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="706"/>
+        <source>1x1</source>
+        <translation>1x1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="730"/>
+        <source>Output Scaling</source>
+        <translation>Масштабирование вывода</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="767"/>
+        <source>RCAS Sharpening Strength</source>
+        <translation>Резкость RCAS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="802"/>
+        <source>100</source>
+        <translation>100</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="870"/>
+        <source>Shader Mode</source>
+        <translation>Режим шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="916"/>
+        <source>Write Color Buffers</source>
+        <translation>Записывать буферы цвета</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="923"/>
+        <source>Strict Rendering Mode</source>
+        <translation>Строгий режим рендеринга</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="930"/>
+        <source>VSync</source>
+        <translation>VSync</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="937"/>
+        <source>Stretch To Display Area</source>
+        <translation>Растянуть на область отображения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="944"/>
+        <source>Multithreaded RSX</source>
+        <translation>Многопоточный RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="951"/>
+        <source>Asynchronous Texture Streaming</source>
+        <translation>Асинхронная потоковая передача текстур</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1026"/>
+        <source>Audio</source>
+        <translation>Аудио</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1036"/>
+        <source>Audio Out</source>
+        <translation>Вывод звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1048"/>
+        <source>Audio Format</source>
+        <translation>Формат звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1073"/>
+        <source>Audio Settings</source>
+        <translation>Настройки звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1079"/>
+        <source>Convert to 16-bit</source>
+        <translation>Конвертировать в 16-бит</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1086"/>
+        <source>Dump to File</source>
+        <translation>Записать в файл</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1132"/>
+        <source>Audio Device</source>
+        <translation>Устройство вывода звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1144"/>
+        <source>Audio Output Format</source>
+        <translation>Формат вывода звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1156"/>
+        <source>Audio Provider</source>
+        <translation>Источник звука</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1168"/>
+        <source>RSXAudio Avport</source>
+        <translation>RSXAudio Avport</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1180"/>
+        <source>Music Handler</source>
+        <translation>Обработчик музыки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1192"/>
+        <source>Volume</source>
+        <translation>Громкость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1213"/>
+        <source>Master: 0%</source>
+        <translation>Основная: 0%</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1259"/>
+        <source>Buffering</source>
+        <translation>Буферизация</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1265"/>
+        <source>Enable Buffering</source>
+        <translation>Включить буферизацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1287"/>
+        <source>Audio Buffer Duration: 0ms</source>
+        <translation>Длительность аудиобуфера: 0мс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1310"/>
+        <source>Enable Time Stretching</source>
+        <translation>Включить растяжение времени</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1332"/>
+        <source>Time Stretching Threshold: 0%</source>
+        <translation>Порог растяжения времени: 0%</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1378"/>
+        <source>Microphone Settings</source>
+        <translation>Настройки микрофона</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1386"/>
+        <source>Microphone Type:</source>
+        <translation>Тип микрофона:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1424"/>
+        <source>Mic1:</source>
+        <translation>Микрофон 1:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1437"/>
+        <source>Mic3:</source>
+        <translation>Микрофон 3:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1478"/>
+        <source>Mic2:</source>
+        <translation>Микрофон 2:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1491"/>
+        <source>Mic4:</source>
+        <translation>Микрофон 4:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1574"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4567"/>
+        <source>I/O</source>
+        <translation>I/O</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1582"/>
+        <source>Guitar Hero Live Emulated Guitar</source>
+        <translation>Эмулируемая гитара Guitar Hero Live</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1594"/>
+        <source>Move Handler</source>
+        <translation>Обработчик Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1606"/>
+        <source>DJ Hero Emulated Turntable</source>
+        <translation>Эмулируемый диджейский стол DJ Hero</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1618"/>
+        <source>Mouse Handler</source>
+        <translation>Обработчик мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1630"/>
+        <source>Buzz! Emulated Controller</source>
+        <translation>Buzz! Эмулируемый контроллер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1642"/>
+        <source>Keyboard Handler</source>
+        <translation>Обработчик клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1654"/>
+        <source>Pad Handler Mode</source>
+        <translation>Режим обработчика геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1666"/>
+        <source>Camera Input</source>
+        <translation>Входной сигнал камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1678"/>
+        <source>Camera Flip</source>
+        <translation>Отражение камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1690"/>
+        <source>Camera</source>
+        <translation>Камера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1702"/>
+        <source>Camera Handler</source>
+        <translation>Обработчик камеры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1714"/>
+        <source>Emulated MIDI Device 1</source>
+        <translation>Эмулируемое MIDI-устройство 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1733"/>
+        <source>Emulated MIDI Device 3</source>
+        <translation>Эмулируемое MIDI-устройство 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1752"/>
+        <source>Emulated MIDI Device 2</source>
+        <translation>Эмулируемое MIDI-устройство 2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1777"/>
+        <source>Enable Background Input</source>
+        <translation>Включить фоновый ввод</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1784"/>
+        <source>Keep Pads Connected</source>
+        <translation>Держать геймпады подключёнными</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1791"/>
+        <source>Show PS Move Cursor</source>
+        <translation>Показывать курсор PS Move</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1798"/>
+        <source>Lock Overlay Input To Player One</source>
+        <translation>Блокировать ввод оверлея для игрока 1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1805"/>
+        <source>Use SDL GameController Database</source>
+        <translation>Использовать базу данных контроллеров SDL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1878"/>
+        <source>System</source>
+        <translation>Система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1888"/>
+        <source>Console Language</source>
+        <translation>Язык консоли</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1900"/>
+        <source>Console Region</source>
+        <translation>Регион консоли</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1912"/>
+        <source>Enter Button Assignment</source>
+        <translation>Назначение кнопки Enter</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1935"/>
+        <source>Disk Cache</source>
+        <translation>Дисковый кэш</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1941"/>
+        <source>Clear cache automatically</source>
+        <translation>Очищать кэш автоматически</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1948"/>
+        <source>Cache size: 3072 MB</source>
+        <translation>Размер кэша: 3072 МБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="1991"/>
+        <source>Keyboard Type</source>
+        <translation>Тип клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2003"/>
+        <source>Date Format</source>
+        <translation>Формат даты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2015"/>
+        <source>Time Format</source>
+        <translation>Формат времени</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2027"/>
+        <source>Console Time</source>
+        <translation>Время консоли</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2072"/>
+        <source>Set to Now</source>
+        <translation>Установить текущее время</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2101"/>
+        <source>Homebrew</source>
+        <translation>Homebrew</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2107"/>
+        <source>Enable /host_root/</source>
+        <translation>Включить /host_root/</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2114"/>
+        <source>Empty /dev_hdd0/tmp/</source>
+        <translation>Очистить /dev_hdd0/tmp/</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2186"/>
+        <source>Network</source>
+        <translation>Сеть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2194"/>
+        <source>Network Configuration</source>
+        <translation>Конфигурация сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2200"/>
+        <source>Network Status</source>
+        <translation>Статус сети</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2212"/>
+        <source>DNS</source>
+        <translation>DNS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2231"/>
+        <source>IP/Hosts switches</source>
+        <translation>IP/Hosts переключатели</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2250"/>
+        <source>Bind address</source>
+        <translation>Адрес привязки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2269"/>
+        <source>Enable UPNP</source>
+        <translation>Включить UPNP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2295"/>
+        <source>PSN Configuration</source>
+        <translation>Конфигурация PSN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2301"/>
+        <source>PSN Status</source>
+        <translation>Статус PSN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2313"/>
+        <source>Country</source>
+        <translation>Страна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2325"/>
+        <source>Enable Clans</source>
+        <translation>Включить кланы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2398"/>
+        <source>Advanced</source>
+        <translation>Дополнительно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2414"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4348"/>
+        <source>Core</source>
+        <translation>Ядро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2420"/>
+        <source>Debug Console Mode</source>
+        <translation>Режим отладочной консоли</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2427"/>
+        <source>Accurate DFMA</source>
+        <translation>Точный DFMA</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2434"/>
+        <source>Accurate RSX reservation access</source>
+        <translation>Точный доступ к резервированию RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2441"/>
+        <source>Accurate SPU DMA</source>
+        <translation>Точный DMA SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2448"/>
+        <source>Disable SPU GETLLAR Spin Optimization</source>
+        <translation>Отключить оптимизацию цикла GETLLAR SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2455"/>
+        <source>Enable SPU Events Busy Loop</source>
+        <translation>Включить цикл ожидания событий SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2462"/>
+        <source>PPU Non-Java Mode Fixup</source>
+        <translation>Исправление режима Non-Java PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2469"/>
+        <source>PPU/SPU LLVM Precompilation</source>
+        <translation>Прекомпиляция LLVM PPU/SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2476"/>
+        <source>Delay each odd MFC Command</source>
+        <translation>Задержка нечётных команд MFC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2483"/>
+        <source>Anti-Cheat Savestates Mode</source>
+        <translation>Режим сохранений Anti-Cheat</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2490"/>
+        <source>SPU-Compatible Savestates Mode</source>
+        <translation>Режим сохранений, совместимый с SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2497"/>
+        <source>Silence All Logs</source>
+        <translation>Отключить все логи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2513"/>
+        <source>Sleep Timers Accuracy</source>
+        <translation>Точность таймеров сна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2531"/>
+        <source>Maximum Number of SPURS Threads</source>
+        <translation>Максимальное количество потоков SPURS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2549"/>
+        <source>Clocks Scale</source>
+        <translation>Масштаб тактовой частоты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2564"/>
+        <source>100%</source>
+        <translation>100%</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2606"/>
+        <source>Firmware Libraries</source>
+        <translation>Библиотеки прошивки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2677"/>
+        <source>Read Depth Buffers</source>
+        <translation>Читать буферы глубины</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2684"/>
+        <source>Write Depth Buffers</source>
+        <translation>Записывать буферы глубины</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2691"/>
+        <source>Read Color Buffers</source>
+        <translation>Читать буферы цвета</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2698"/>
+        <source>Handle RSX memory tiling</source>
+        <translation>Обрабатывать тайлинг памяти RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2705"/>
+        <source>Disable Vertex Cache</source>
+        <translation>Отключить кэш вершин</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2712"/>
+        <source>Allow Host GPU Labels (Experimental)</source>
+        <translation>Разрешить метки GPU хоста (Эксп.)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2719"/>
+        <source>Force Hardware MSAA Resolve</source>
+        <translation>Принудительное аппаратное разрешение MSAA</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2726"/>
+        <source>Use Re-BAR memory for GPU uploads</source>
+        <translation>Использовать память Re-BAR для загрузки GPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2733"/>
+        <source>Disable MSL Fast Math</source>
+        <translation>Отключить быструю математику MSL</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2749"/>
+        <source>RSX FIFO Accuracy</source>
+        <translation>Точность RSX FIFO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2767"/>
+        <source>Exclusive Fullscreen Mode</source>
+        <translation>Эксклюзивный полноэкранный режим</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2785"/>
+        <source>Driver Wake-Up Delay</source>
+        <translation>Задержка пробуждения драйвера</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2800"/>
+        <source>1 µs</source>
+        <translation>1 мкс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2828"/>
+        <source>VBlank Frequency</source>
+        <translation>Частота VBlank</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2843"/>
+        <source>60 Hz</source>
+        <translation>60 Гц</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2862"/>
+        <source>VBlank NTSC Fixup</source>
+        <translation>Исправление NTSC для VBlank</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2934"/>
+        <source>Emulator</source>
+        <translation>Эмулятор</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2944"/>
+        <source>Emulator Settings</source>
+        <translation>Настройки эмулятора</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2950"/>
+        <source>Exit RPCS3 when process finishes</source>
+        <translation>Завершать RPCS3 по окончании процесса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2957"/>
+        <source>Pause emulation on RPCS3 focus loss</source>
+        <translation>Приостанавливать эмуляцию при потере фокуса RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2964"/>
+        <source>Pause emulation after loading savestates</source>
+        <translation>Приостанавливать эмуляцию после загрузки состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2971"/>
+        <source>Pause emulation during home menu</source>
+        <translation>Приостанавливать эмуляцию в домашнем меню</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2978"/>
+        <source>Prevent display sleep while running games</source>
+        <translation>Запрещать переход дисплея в режим сна во время игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2985"/>
+        <source>Show trophy popups</source>
+        <translation>Показывать всплывающие уведомления о трофеях</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2992"/>
+        <source>Show RPCN popups</source>
+        <translation>Показывать всплывающие уведомления RPCN</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="2999"/>
+        <source>Show shader compilation hint</source>
+        <translation>Показывать подсказку компиляции шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3006"/>
+        <source>Show PPU compilation hint</source>
+        <translation>Показывать подсказку компиляции PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3013"/>
+        <source>Show autosave/autoload hint</source>
+        <translation>Показывать подсказку автосохранения/автозагрузки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3020"/>
+        <source>Show analog limiter toggle hint</source>
+        <translation>Показывать подсказку переключения ограничителя аналогового ввода</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3027"/>
+        <source>Show pressure intensity toggle hint</source>
+        <translation>Показывать подсказку переключения интенсивности нажатия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3034"/>
+        <source>Show mouse and keyboard toggle hint</source>
+        <translation>Показывать подсказку переключения мыши и клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3041"/>
+        <source>Show capture hints</source>
+        <translation>Показывать подсказки захвата</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3048"/>
+        <source>Start games in fullscreen mode</source>
+        <translation>Запускать игры в полноэкранном режиме</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3055"/>
+        <source>Use native user interface</source>
+        <translation>Использовать нативный интерфейс пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3062"/>
+        <source>Record with overlays</source>
+        <translation>Записывать с оверлеями</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3069"/>
+        <source>Enable GameMode</source>
+        <translation>Включить GameMode</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3095"/>
+        <source>Max LLVM Compile Threads</source>
+        <translation>Максимум потоков компиляции LLVM</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3107"/>
+        <source>Max Shader Compile Threads</source>
+        <translation>Максимум потоков компиляции шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3123"/>
+        <source>Viewport</source>
+        <translation>Окно просмотра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3129"/>
+        <source>Ignore doubleclicks for Fullscreen</source>
+        <translation>Игнорировать двойной клик для полного экрана</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3136"/>
+        <source>Ignore keyboard hotkeys</source>
+        <translation>Игнорировать горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3143"/>
+        <source>Show mouse cursor in Fullscreen</source>
+        <translation>Показывать курсор мыши в полноэкранном режиме</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3150"/>
+        <source>Lock mouse cursor in Fullscreen</source>
+        <translation>Блокировать курсор мыши в полноэкранном режиме</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3172"/>
+        <source>Hide mouse cursor if idle</source>
+        <translation>Скрывать курсор мыши при бездействии</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3188"/>
+        <source>ms</source>
+        <translation>мс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3225"/>
+        <source>Resize game window on boot</source>
+        <translation>Изменять размер окна игры при запуске</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3232"/>
+        <source>Resize manually</source>
+        <translation>Изменять вручную</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3241"/>
+        <source>Width</source>
+        <translation>Ширина</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3272"/>
+        <source>Height</source>
+        <translation>Высота</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3314"/>
+        <source>Shader Loading Screen</source>
+        <translation>Экран загрузки шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3320"/>
+        <source>Allow custom background</source>
+        <translation>Разрешить собственный фон</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3327"/>
+        <source>Background darkening:</source>
+        <translation>Затемнение фона:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3341"/>
+        <source>Background blur:</source>
+        <translation>Размытие фона:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3374"/>
+        <source>Game Window Title</source>
+        <translation>Заголовок окна игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3392"/>
+        <source>Reset the game window title to default</source>
+        <translation>Сбросить заголовок окна игры по умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3402"/>
+        <source>Edit the game window title</source>
+        <translation>Редактировать заголовок окна игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3405"/>
+        <source>Edit</source>
+        <translation>Редактировать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3421"/>
+        <source>Performance Overlay</source>
+        <translation>Оверлей производительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3427"/>
+        <source>Enable performance overlay</source>
+        <translation>Включить оверлей производительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3434"/>
+        <source>Show framerate graph</source>
+        <translation>Показывать график частоты кадров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3441"/>
+        <source>Show frametime graph</source>
+        <translation>Показывать график времени кадра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3463"/>
+        <source>Detail Level:</source>
+        <translation>Уровень детализации:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3491"/>
+        <source>Position:</source>
+        <translation>Положение:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3504"/>
+        <source>Horizontal Margin:</source>
+        <translation>Горизонтальный отступ:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3513"/>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3534"/>
+        <source>Centered</source>
+        <translation>По центру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3525"/>
+        <source>Vertical Margin:</source>
+        <translation>Вертикальный отступ:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3561"/>
+        <source>Update Interval:</source>
+        <translation>Интервал обновления:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3599"/>
+        <source>Font Size: </source>
+        <translation>Размер шрифта: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3631"/>
+        <source>Opacity:</source>
+        <translation>Непрозрачность:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3660"/>
+        <source>Framerate datapoints:</source>
+        <translation>Точек данных частоты кадров:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3689"/>
+        <source>Frametime datapoints:</source>
+        <translation>Точек данных времени кадра:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3774"/>
+        <source>GUI</source>
+        <translation>GUI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3784"/>
+        <source>UI Stylesheets</source>
+        <translation>Темы оформления UI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3793"/>
+        <source>Apply</source>
+        <translation>Применить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3803"/>
+        <source>UI Colors</source>
+        <translation>Цвета UI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3821"/>
+        <source>Use custom UI Colors</source>
+        <translation>Использовать пользовательские цвета UI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3828"/>
+        <source>Gamelist icons</source>
+        <translation>Иконки списка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3835"/>
+        <source>Save manager icons</source>
+        <translation>Иконки менеджера сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3842"/>
+        <source>Trophy manager icons</source>
+        <translation>Иконки менеджера трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3872"/>
+        <source>Log</source>
+        <translation>Журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3899"/>
+        <source>Maximum log blocks (0 = no limit)</source>
+        <translation>Максимум блоков журнала (0 = без ограничений)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3934"/>
+        <source>Maximum TTY blocks (0 = no limit)</source>
+        <translation>Максимум блоков TTY (0 = без ограничений)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3954"/>
+        <source>Pad Input</source>
+        <translation>Ввод с геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3960"/>
+        <source>Enable Pad Navigation</source>
+        <translation>Включить навигацию с геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3967"/>
+        <source>Allow Global Pad Navigation</source>
+        <translation>Разрешить глобальную навигацию с геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="3997"/>
+        <source>UI Options</source>
+        <translation>Параметры UI</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4003"/>
+        <source>Show Welcome Screen</source>
+        <translation>Показывать экран приветствия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4010"/>
+        <source>Show Exit Game Dialog</source>
+        <translation>Показывать диалог выхода из игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4017"/>
+        <source>Show Boot Game Dialog</source>
+        <translation>Показывать диалог запуска игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4024"/>
+        <source>Show PKG Installation Dialog</source>
+        <translation>Показывать диалог установки PKG</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4031"/>
+        <source>Show PUP Installation Dialog</source>
+        <translation>Показывать диалог установки PUP</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4038"/>
+        <source>Show Obsolete Settings Dialog</source>
+        <translation>Показывать диалог устаревших настроек</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4045"/>
+        <source>Show Duplicate Buttons Dialog</source>
+        <translation>Показывать диалог дублирующихся кнопок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4052"/>
+        <source>Show Restart Dialog</source>
+        <translation>Показывать диалог перезапуска</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4078"/>
+        <source>Check for updates on startup</source>
+        <translation>Проверять обновления при запуске</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4090"/>
+        <source>Discord</source>
+        <translation>Discord</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4096"/>
+        <source>Use Discord Rich Presence</source>
+        <translation>Использовать Discord Rich Presence</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4103"/>
+        <source>Discord Status:</source>
+        <translation>Статус Discord:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4126"/>
+        <source>Installation ID</source>
+        <translation>ID установки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4132"/>
+        <source>UUID-placeholder</source>
+        <translation>UUID-заглушка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4142"/>
+        <source>Create new ID</source>
+        <translation>Создать новый ID</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4201"/>
+        <source>Debug</source>
+        <translation>Отладка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4221"/>
+        <source>Debug Output</source>
+        <translation>Вывод отладки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4228"/>
+        <source>Debug Overlay</source>
+        <translation>Отладочный оверлей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4235"/>
+        <source>Disable FIFO Reordering</source>
+        <translation>Отключить переупорядочивание FIFO</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4242"/>
+        <source>Disable Video Output</source>
+        <translation>Отключить вывод видео</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4249"/>
+        <source>Disable Vulkan Memory Allocator</source>
+        <translation>Отключить распределитель памяти Vulkan</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4256"/>
+        <source>Disable ZCull Occlusion Queries</source>
+        <translation>Отключить запросы перекрытия ZCull</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4263"/>
+        <source>Force CPU Blit Emulation</source>
+        <translation>Принудительная эмуляция CPU Blit</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4270"/>
+        <source>Force GPU Texture Scaling</source>
+        <translation>Принудительное масштабирование текстур GPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4277"/>
+        <source>Log Shader Programs</source>
+        <translation>Журналировать шейдерные программы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4287"/>
+        <source>Renderdoc Compatibility Mode</source>
+        <translation>Режим совместимости Renderdoc</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4294"/>
+        <source>Strict Texture Flushing</source>
+        <translation>Строгий сброс текстур</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4301"/>
+        <source>Use High Precision Z-Buffer</source>
+        <translation>Использовать Z-буфер высокой точности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4308"/>
+        <source>Disable Asynchronous Memory Manager</source>
+        <translation>Отключить асинхронный менеджер памяти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4315"/>
+        <source>Disable On-Disk Shader Cache</source>
+        <translation>Отключить дисковый кэш шейдеров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4322"/>
+        <source>Disable Hardware ColorSpace Remapping</source>
+        <translation>Отключить аппаратное переназначение цветового пространства</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4354"/>
+        <source>Automatically start games after boot</source>
+        <translation>Автоматически запускать игры после загрузки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4361"/>
+        <source>Enable performance report</source>
+        <translation>Включить отчёт о производительности</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4368"/>
+        <source>Hook static functions</source>
+        <translation>Перехватывать статические функции</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4375"/>
+        <source>PPU Debug</source>
+        <translation>Отладка PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4382"/>
+        <source>SPU Debug</source>
+        <translation>Отладка SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4389"/>
+        <source>MFC Debug</source>
+        <translation>Отладка MFC</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4396"/>
+        <source>Set DAZ and FTZ</source>
+        <translation>Установить DAZ и FTZ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4403"/>
+        <source>Accurate PPU Saturation Bit</source>
+        <translation>Точный бит насыщения PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4410"/>
+        <source>Accurate PPU Non-Java Mode</source>
+        <translation>Точный режим Non-Java PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4417"/>
+        <source>Accurate PPU Vector NaN Handling</source>
+        <translation>Точная обработка NaN векторов PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4424"/>
+        <source>Accurate PPU Float Condition Control</source>
+        <translation>Точный контроль условий с плавающей точкой PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4431"/>
+        <source>Accurate Cache Line Stores</source>
+        <translation>Точные операции записи строк кэша</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4438"/>
+        <source>PPU Vector NaN Fixup</source>
+        <translation>Исправление NaN векторов PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4445"/>
+        <source>SPU Profiler</source>
+        <translation>Профилировщик SPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4486"/>
+        <source>Accurate PPU 128 Reservations</source>
+        <translation>Точные 128-битные резервирования PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4498"/>
+        <source>PPU Thread Count</source>
+        <translation>Количество потоков PPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4510"/>
+        <source>LOD Bias Offset</source>
+        <translation>Смещение LOD Bias</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4539"/>
+        <source>Vulkan Queue Scheduler</source>
+        <translation>Планировщик очереди Vulkan</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4551"/>
+        <source>Log Levels</source>
+        <translation>Уровни журналирования</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4557"/>
+        <source>Configure</source>
+        <translation>Настроить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4573"/>
+        <source>Debug Overlay For Pad Input</source>
+        <translation>Отладочный оверлей ввода с геймпада</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.ui" line="4580"/>
+        <source>Debug Overlay For Mouse Input</source>
+        <translation>Отладочный оверлей ввода мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="112"/>
+        <source>Save custom configuration</source>
+        <comment>Settings dialog</comment>
+        <translation>Сохранить пользовательскую конфигурацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="136"/>
+        <source>Settings: [%0] %1</source>
+        <comment>Settings dialog</comment>
+        <translation>Настройки: [%0] %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="141"/>
+        <source>Settings</source>
+        <comment>Settings dialog</comment>
+        <translation>Настройки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="275"/>
+        <source>Changing the thread scheduler is not supported on CPUs with less than %0 threads.
+
+Control how RPCS3 utilizes the threads of your system.
+Each option heavily depends on the game and on your CPU, it&apos;s recommended to try each option to find out which performs the best.</source>
+        <translation>Изменение планировщика потоков не поддерживается на процессорах с менее чем %0 потоками.
+
+Управляйте тем, как RPCS3 использует потоки вашей системы.
+Каждый вариант сильно зависит от игры и процессора — рекомендуется попробовать все варианты, чтобы найти оптимальный.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="289"/>
+        <source>Auto</source>
+        <comment>Preferred SPU threads</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="461"/>
+        <source>720p (Recommended)</source>
+        <comment>Resolution</comment>
+        <translation>720p (рекомендуется)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="499"/>
+        <source>Display (%1)</source>
+        <comment>Frame Limit</comment>
+        <translation>Дисплей (%1)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="516"/>
+        <source>Auto</source>
+        <comment>Anisotropic filter override</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="522"/>
+        <source>%1x</source>
+        <comment>Anisotropic filter override</comment>
+        <translation>%1x</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="534"/>
+        <source>Precise (Slowest)</source>
+        <translation>Точный (медленнее всего)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="535"/>
+        <source>Approximate (Fast)</source>
+        <translation>Приближённый (быстро)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="536"/>
+        <source>Relaxed (Fastest)</source>
+        <translation>Упрощённый (быстрее всего)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="661"/>
+        <source>100% (1280x720) (Default)</source>
+        <comment>Resolution scale</comment>
+        <translation>100% (1280x720) (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="663"/>
+        <source>%1% (%2x%3)</source>
+        <comment>Resolution scale</comment>
+        <translation>%1% (%2x%3)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="689"/>
+        <source>%1x%1 (Default)</source>
+        <comment>Minimum scalable dimension</comment>
+        <translation>%1x%1 (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="691"/>
+        <source>%1x%1</source>
+        <comment>Minimum scalable dimension</comment>
+        <translation>%1x%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="713"/>
+        <source>%1% (Default)</source>
+        <translation>%1% (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="715"/>
+        <source>%1%</source>
+        <translation>%1%</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="785"/>
+        <source>Not needed for %0 renderer</source>
+        <comment>Graphics adapter</comment>
+        <translation>Не нужно для рендерера %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="954"/>
+        <source>Default</source>
+        <translation>По умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="972"/>
+        <source>Unknown device</source>
+        <translation>Неизвестное устройство</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1133"/>
+        <source>Master: %0 %</source>
+        <comment>Master volume</comment>
+        <translation>Основная: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1136"/>
+        <source>Audio Buffer Duration: %0 ms</source>
+        <comment>Audio buffer duration</comment>
+        <translation>Длительность аудиобуфера: %0 мс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1139"/>
+        <source>Time Stretching Threshold: %0 %</source>
+        <comment>Time stretching threshold</comment>
+        <translation>Порог растяжения времени: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1169"/>
+        <source>None</source>
+        <comment>Camera Device</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1170"/>
+        <source>Default</source>
+        <comment>Camera Device</comment>
+        <translation>По умолчанию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1380"/>
+        <source>dd MMM yyyy HH:mm</source>
+        <translation>dd MMM yyyy HH:mm</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1389"/>
+        <source>Maximum size: %0 MB</source>
+        <comment>Maximum cache size</comment>
+        <translation>Максимальный размер: %0 МБ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1564"/>
+        <source>Unlimited (Default)</source>
+        <comment>Max SPURS threads</comment>
+        <translation>Неограничено (по умолчанию)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1591"/>
+        <source>%0 Hz</source>
+        <comment>VBlank rate</comment>
+        <translation>%0 Гц</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1600"/>
+        <source>%0 %</source>
+        <comment>Clocks scale</comment>
+        <translation>%0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1665"/>
+        <source>Do not touch libsysutil libs, development purposes only, will cause game crashes.</source>
+        <translation>Не трогать библиотеки libsysutil — только для разработки, вызовет краши игр.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1672"/>
+        <source>Search libraries</source>
+        <comment>Library search box</comment>
+        <translation>Поиск библиотек</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1784"/>
+        <source>All (%1)</source>
+        <comment>Max LLVM Compile Threads</comment>
+        <translation>Все (%1)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1788"/>
+        <source>Auto</source>
+        <comment>Max Shader Compile Threads</comment>
+        <translation>Авто</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1926"/>
+        <source>Update Interval: %0 ms</source>
+        <comment>Performance overlay update interval</comment>
+        <translation>Интервал обновления: %0 мс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1929"/>
+        <source>Font Size: %0 px</source>
+        <comment>Performance overlay font size</comment>
+        <translation>Размер шрифта: %0 пикс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1932"/>
+        <source>Opacity: %0 %</source>
+        <comment>Performance overlay opacity</comment>
+        <translation>Непрозрачность: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1935"/>
+        <source>Framerate datapoints: %0</source>
+        <comment>Framerate graph datapoints</comment>
+        <translation>Точек данных частоты кадров: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1938"/>
+        <source>Frametime datapoints: %0</source>
+        <comment>Frametime graph datapoints</comment>
+        <translation>Точек данных времени кадра: %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1941"/>
+        <source>Background darkening: %0 %</source>
+        <comment>Shader load background darkening</comment>
+        <translation>Затемнение фона: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1944"/>
+        <source>Background blur: %0 %</source>
+        <comment>Shader load background blur</comment>
+        <translation>Размытие фона: %0 %</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1949"/>
+        <source>px</source>
+        <comment>Performance overlay margin x</comment>
+        <translation>пкс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="1952"/>
+        <source>px</source>
+        <comment>Performance overlay margin y</comment>
+        <translation>пкс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2065"/>
+        <source>My Game</source>
+        <comment>Game window title</comment>
+        <translation>Моя игра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2100"/>
+        <source>GPU Model</source>
+        <comment>Game window title</comment>
+        <translation>Модель GPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2101"/>
+        <source>CPU Model</source>
+        <comment>Game window title</comment>
+        <translation>Модель CPU</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2102"/>
+        <source>Thread Count</source>
+        <comment>Game window title</comment>
+        <translation>Количество потоков</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2103"/>
+        <source>System Memory</source>
+        <comment>Game window title</comment>
+        <translation>Системная память</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2104"/>
+        <source>Framerate</source>
+        <comment>Game window title</comment>
+        <translation>Частота кадров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2105"/>
+        <source>Renderer</source>
+        <comment>Game window title</comment>
+        <translation>Рендерер</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2106"/>
+        <source>Title</source>
+        <comment>Game window title</comment>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2107"/>
+        <source>Title ID</source>
+        <comment>Game window title</comment>
+        <translation>ID названия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2108"/>
+        <source>RPCS3 Version</source>
+        <comment>Game window title</comment>
+        <translation>Версия RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2118"/>
+        <source>Glossary:
+
+%0
+Preview:
+
+%1
+</source>
+        <comment>Game window title</comment>
+        <translation>Словарь:
+
+%0
+Предпросмотр:
+
+%1
+</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2125"/>
+        <source>Game Window Title Format</source>
+        <comment>Game window title</comment>
+        <translation>Формат заголовка окна игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2220"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2220"/>
+        <source>Failed to create new installation ID!</source>
+        <translation>Не удалось создать новый ID установки!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2283"/>
+        <source>Yes</source>
+        <comment>Updates</comment>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2284"/>
+        <source>Background</source>
+        <comment>Updates</comment>
+        <translation>Фоновая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2285"/>
+        <source>Automatic</source>
+        <comment>Updates</comment>
+        <translation>Автоматическая</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2286"/>
+        <source>No</source>
+        <comment>Updates</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2367"/>
+        <source>Choose gamelist icon color</source>
+        <comment>Settings: color dialog</comment>
+        <translation>Выбрать цвет иконки списка игр</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2371"/>
+        <source>Choose save manager icon color</source>
+        <comment>Settings: color dialog</comment>
+        <translation>Выбрать цвет иконки менеджера сохранений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2375"/>
+        <source>Choose trophy manager icon color</source>
+        <comment>Settings: color dialog</comment>
+        <translation>Выбрать цвет иконки менеджера трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2490"/>
+        <source>Always Enabled</source>
+        <comment>Accurate PPU 128 Reservations</comment>
+        <translation>Всегда включено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2491"/>
+        <source>Disabled</source>
+        <comment>Accurate PPU 128 Reservations</comment>
+        <translation>Отключено</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2578"/>
+        <source>None</source>
+        <comment>Stylesheets</comment>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2583"/>
+        <source>Native (%0)</source>
+        <comment>Stylesheets</comment>
+        <translation>Нативный (%0)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2586"/>
+        <source>Default (Bright)</source>
+        <comment>Stylesheets</comment>
+        <translation>По умолчанию (светлый)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2642"/>
+        <source>Remove obsolete settings?</source>
+        <translation>Удалить устаревшие настройки?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/settings_dialog.cpp" line="2643"/>
+        <source>Your config file contains one or more obsolete entries.&lt;br&gt;Consider that a removal might render them invalid for other versions of RPCS3.&lt;br&gt;&lt;br&gt;Do you wish to let the program remove them for you now?&lt;br&gt;This change will only be final when you save the config.</source>
+        <translation>Ваш файл конфигурации содержит одну или несколько устаревших записей.&lt;br&gt;Учтите, что их удаление может сделать конфигурацию несовместимой с другими версиями RPCS3.&lt;br&gt;&lt;br&gt;Хотите, чтобы программа удалила их сейчас?&lt;br&gt;Изменение вступит в силу только после сохранения конфигурации.</translation>
+    </message>
+</context>
+<context>
+    <name>shortcut_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_dialog.ui" line="14"/>
+        <source>Shortcuts</source>
+        <translation>Горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_dialog.ui" line="22"/>
+        <source>Main Window Shortcuts</source>
+        <translation>Горячие клавиши главного окна</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_dialog.ui" line="47"/>
+        <source>Game Window Shortcuts</source>
+        <translation>Горячие клавиши окна игры</translation>
+    </message>
+</context>
+<context>
+    <name>shortcut_settings</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="65"/>
+        <source>Start</source>
+        <translation>Start</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="66"/>
+        <source>Stop</source>
+        <translation>Стоп</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="67"/>
+        <source>Pause</source>
+        <translation>Пауза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="68"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="84"/>
+        <source>Restart</source>
+        <translation>Перезапустить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="69"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="72"/>
+        <source>Toggle Fullscreen</source>
+        <translation>Переключить полноэкранный режим</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="70"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="73"/>
+        <source>Exit Fullscreen</source>
+        <translation>Выйти из полноэкранного режима</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="71"/>
+        <source>Refresh</source>
+        <translation>Обновить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="74"/>
+        <source>Add Log Mark</source>
+        <translation>Добавить метку в журнал</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="75"/>
+        <source>Mouse lock</source>
+        <translation>Блокировка мыши</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="76"/>
+        <source>Start/Stop Recording</source>
+        <translation>Начать/остановить запись</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="77"/>
+        <source>Screenshot</source>
+        <translation>Скриншот</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="78"/>
+        <source>Pause/Play</source>
+        <translation>Пауза/Воспроизведение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="79"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="80"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="81"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="82"/>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="83"/>
+        <source>Savestate</source>
+        <translation>Сохранение состояния</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="85"/>
+        <source>RSX Capture</source>
+        <translation>Захват RSX</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="86"/>
+        <source>Toggle Framelimit</source>
+        <translation>Переключить ограничение кадров</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="87"/>
+        <source>Toggle Keyboard</source>
+        <translation>Переключить клавиатуру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="88"/>
+        <source>Open Home Menu</source>
+        <translation>Открыть домашнее меню</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="89"/>
+        <source>Mute/Unmute Audio</source>
+        <translation>Вкл./откл. звук</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="90"/>
+        <source>Volume Up</source>
+        <translation>Увеличить громкость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="91"/>
+        <source>Volume Down</source>
+        <translation>Уменьшить громкость</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/shortcut_settings.cpp" line="92"/>
+        <source>Toggle Mouse-based Gyro</source>
+        <translation>Переключить гироскоп на основе мыши</translation>
+    </message>
+</context>
+<context>
+    <name>skylander_creator_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="532"/>
+        <source>Skylander Creator</source>
+        <translation>Создание Skylander</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="547"/>
+        <source>--Unknown--</source>
+        <translation>--Неизвестно--</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="566"/>
+        <source>ID:</source>
+        <translation>ID:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="567"/>
+        <source>Variant:</source>
+        <translation>Вариант:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="580"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="581"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="608"/>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="614"/>
+        <source>Error converting value</source>
+        <translation>Ошибка преобразования значения</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="608"/>
+        <source>ID entered is invalid!</source>
+        <translation>Введённый ID недействителен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="614"/>
+        <source>Variant entered is invalid!</source>
+        <translation>Введённый вариант недействителен!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="629"/>
+        <source>Create Skylander File</source>
+        <translation>Создать файл Skylander</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="629"/>
+        <source>Skylander Object (*.sky);;All Files (*)</source>
+        <translation>Объект Skylander (*.sky);;Все файлы (*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="638"/>
+        <source>Failed to create skylander file!</source>
+        <translation>Не удалось создать файл Skylander!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="638"/>
+        <source>Failed to create skylander file:
+%1</source>
+        <translation>Не удалось создать файл Skylander:
+%1</translation>
+    </message>
+</context>
+<context>
+    <name>skylander_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="681"/>
+        <source>Skylanders Manager</source>
+        <translation>Менеджер Skylanders</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="696"/>
+        <source>Active Portal Skylanders:</source>
+        <translation>Активные Skylanders на портале:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="707"/>
+        <source>Skylander %1</source>
+        <translation>Skylander %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="711"/>
+        <source>Clear</source>
+        <translation>Очистить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="712"/>
+        <source>Create</source>
+        <translation>Создать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="713"/>
+        <source>Load</source>
+        <translation>Загрузить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="770"/>
+        <source>Select Skylander File</source>
+        <translation>Выбрать файл Skylander</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="770"/>
+        <source>Skylander (*.sky *.bin *.dmp *.dump);;All Files (*)</source>
+        <translation>Skylander (*.sky *.bin *.dmp *.dump);;Все файлы (*)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="786"/>
+        <source>Failed to open the skylander file!</source>
+        <translation>Не удалось открыть файл Skylander!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="786"/>
+        <source>Failed to open the skylander file(%1)!
+File may already be in use on the portal.</source>
+        <translation>Не удалось открыть файл Skylander (%1)!
+Файл уже может использоваться на портале.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="793"/>
+        <source>Failed to read the skylander file!</source>
+        <translation>Не удалось прочитать файл Skylander!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="793"/>
+        <source>Failed to read the skylander file(%1)!
+File was too small.</source>
+        <translation>Не удалось прочитать файл Skylander (%1)!
+Файл слишком маленький.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="823"/>
+        <source>Unknown (Id:%1 Var:%2)</source>
+        <translation>Неизвестный (Id:%1 Вар:%2)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/skylander_dialog.cpp" line="828"/>
+        <source>None</source>
+        <translation>Нет</translation>
+    </message>
+</context>
+<context>
+    <name>sound_effect_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="18"/>
+        <source>Sound Effects</source>
+        <translation>Звуковые эффекты</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="21"/>
+        <source>You can import sound effects for the RPCS3 overlays here.
+The file format is .wav and you should try to make the sounds as short as possible.</source>
+        <translation>Здесь можно импортировать звуковые эффекты для оверлеев RPCS3.
+Формат файла — .wav, старайтесь делать звуки как можно короче.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="33"/>
+        <source>Cursor</source>
+        <translation>Курсор</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="34"/>
+        <source>Accept</source>
+        <translation>Принять</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="35"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="36"/>
+        <source>Onscreen keyboard accept</source>
+        <translation>Принятие экранной клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="37"/>
+        <source>Onscreen keyboard cancel</source>
+        <translation>Отмена экранной клавиатуры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="38"/>
+        <source>Dialog popup</source>
+        <translation>Всплывающий диалог</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="39"/>
+        <source>Error dialog popup</source>
+        <translation>Всплывающий диалог ошибки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="40"/>
+        <source>Trophy popup</source>
+        <translation>Всплывающее уведомление трофея</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="49"/>
+        <source>Remove sound effect?</source>
+        <translation>Удалить звуковой эффект?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="49"/>
+        <source>Do you really want to remove the &apos;%0&apos; sound effect.</source>
+        <translation>Вы действительно хотите удалить звуковой эффект &apos;%0&apos;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="61"/>
+        <source>Select Audio File to Import</source>
+        <translation>Выбрать аудиофайл для импорта</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="61"/>
+        <source>WAV (*.wav);;</source>
+        <translation>WAV (*.wav);;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="126"/>
+        <source>Remove</source>
+        <translation>Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/sound_effect_manager_dialog.cpp" line="132"/>
+        <source>Import</source>
+        <translation>Импортировать</translation>
+    </message>
+</context>
+<context>
+    <name>system_cmd_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="21"/>
+        <source>System Commands | %1</source>
+        <translation>Системные команды | %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="25"/>
+        <source>Send Command</source>
+        <translation>Отправить команду</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="28"/>
+        <source>Send Custom Command</source>
+        <translation>Отправить пользовательскую команду</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="79"/>
+        <source>Select Command</source>
+        <translation>Выбрать команду</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="84"/>
+        <source>Select Custom Command</source>
+        <translation>Выбрать пользовательскую команду</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="89"/>
+        <source>Select Value</source>
+        <translation>Выбрать значение</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="118"/>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="126"/>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="141"/>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="149"/>
+        <source>Listen!</source>
+        <translation>Внимание!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="118"/>
+        <source>The selected command is bugged.
+Please contact a developer.</source>
+        <translation>Выбранная команда содержит ошибку.
+Пожалуйста, свяжитесь с разработчиком.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="126"/>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="149"/>
+        <source>Please select a proper value first.</source>
+        <translation>Пожалуйста, сначала выберите правильное значение.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/system_cmd_dialog.cpp" line="141"/>
+        <source>Please select a proper custom command first.</source>
+        <translation>Пожалуйста, сначала выберите правильную команду.</translation>
+    </message>
+</context>
+<context>
+    <name>system_state</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.h" line="45"/>
+        <source>No Thread</source>
+        <translation>Нет потока</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.h" line="46"/>
+        <source>Run</source>
+        <translation>Запуск</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/debugger_frame.h" line="47"/>
+        <source>Pause</source>
+        <translation>Пауза</translation>
+    </message>
+</context>
+<context>
+    <name>trophy_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="53"/>
+        <source>Trophy Manager</source>
+        <translation>Менеджер трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="79"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1200"/>
+        <source>Progress: %1% (%2/%3)</source>
+        <translation>Прогресс: %1% (%2/%3)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="160"/>
+        <source>Show Not Earned Trophies</source>
+        <translation>Показывать незаработанные трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="164"/>
+        <source>Show Earned Trophies</source>
+        <translation>Показывать заработанные трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="168"/>
+        <source>Show Hidden Trophies</source>
+        <translation>Показывать скрытые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="172"/>
+        <source>Show Bronze Trophies</source>
+        <translation>Показывать бронзовые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="176"/>
+        <source>Show Silver Trophies</source>
+        <translation>Показывать серебряные трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="180"/>
+        <source>Show Gold Trophies</source>
+        <translation>Показывать золотые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="184"/>
+        <source>Show Platinum Trophies</source>
+        <translation>Показывать платиновые трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="189"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="251"/>
+        <source>Trophy Icon Size: %0x%1</source>
+        <translation>Размер иконки трофея: %0x%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="192"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="280"/>
+        <source>Game Icon Size: %0x%1</source>
+        <translation>Размер иконки игры: %0x%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="203"/>
+        <source>Choose Game</source>
+        <translation>Выбрать игру</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="208"/>
+        <source>Trophy Info</source>
+        <translation>Информация о трофеях</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="213"/>
+        <source>Trophy View Options</source>
+        <translation>Параметры отображения трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="224"/>
+        <source>Icon Options</source>
+        <translation>Параметры иконок</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="415"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="449"/>
+        <source>Icon</source>
+        <translation>Иконка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="416"/>
+        <source>Name</source>
+        <translation>Название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="417"/>
+        <source>Description</source>
+        <translation>Описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="418"/>
+        <source>Type</source>
+        <translation>Тип</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="419"/>
+        <source>Status</source>
+        <translation>Статус</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="420"/>
+        <source>ID</source>
+        <translation>ID</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="421"/>
+        <source>Platinum Relevant</source>
+        <translation>Имеет значение для платины</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="422"/>
+        <source>Time Unlocked</source>
+        <translation>Время разблокировки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="432"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="462"/>
+        <source>Show Icons</source>
+        <translation>Показывать иконки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="433"/>
+        <source>Show Names</source>
+        <translation>Показывать названия</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="434"/>
+        <source>Show Descriptions</source>
+        <translation>Показывать описания</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="435"/>
+        <source>Show Types</source>
+        <translation>Показывать типы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="436"/>
+        <source>Show Status</source>
+        <translation>Показывать статус</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="437"/>
+        <source>Show IDs</source>
+        <translation>Показывать ID</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="438"/>
+        <source>Show Platinum Relevant</source>
+        <translation>Показывать значимые для платины</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="439"/>
+        <source>Show Time Unlocked</source>
+        <translation>Показывать время разблокировки</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="450"/>
+        <source>Game</source>
+        <translation>Игра</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="451"/>
+        <source>Progress</source>
+        <translation>Прогресс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="452"/>
+        <source>Trophies</source>
+        <translation>Трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="463"/>
+        <source>Show Games</source>
+        <translation>Показывать игры</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="464"/>
+        <source>Show Progress</source>
+        <translation>Показывать прогресс</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="465"/>
+        <source>Show Trophies</source>
+        <translation>Показывать трофеи</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="875"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1012"/>
+        <source>&amp;Open Trophy Directory</source>
+        <translation>&amp;Открыть папку трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="895"/>
+        <source>&amp;Copy Info</source>
+        <translation>&amp;Копировать информацию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="899"/>
+        <source>&amp;Copy Name + Description</source>
+        <translation>&amp;Копировать название и описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="909"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1040"/>
+        <source>&amp;Copy Name</source>
+        <translation>&amp;Копировать название</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="919"/>
+        <source>&amp;Copy Description</source>
+        <translation>&amp;Копировать описание</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="938"/>
+        <source>&amp;Lock Trophy</source>
+        <translation>&amp;Заблокировать трофей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="938"/>
+        <source>&amp;Unlock Trophy</source>
+        <translation>&amp;Разблокировать трофей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="943"/>
+        <source>Action not permitted.</source>
+        <translation>Действие не разрешено.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="943"/>
+        <source>Platinum trophies can only be unlocked ingame.</source>
+        <translation>Платиновые трофеи можно разблокировать только в игре.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="986"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1284"/>
+        <source>Earned</source>
+        <translation>Получен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="986"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1284"/>
+        <source>Not Earned</source>
+        <translation>Не получен</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="990"/>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1282"/>
+        <source>Unknown</source>
+        <translation>Неизвестно</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1011"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1021"/>
+        <source>Delete Confirmation</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1021"/>
+        <source>Are you sure you want to delete the trophies for:
+%1?</source>
+        <translation>Вы уверены, что хотите удалить трофеи для:
+%1?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1084"/>
+        <source>Loading trophies</source>
+        <translation>Загрузка трофеев</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1084"/>
+        <source>Loading trophy data, please wait...</source>
+        <translation>Загрузка данных трофеев, пожалуйста, подождите...</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1084"/>
+        <source>Cancel</source>
+        <translation>Отмена</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1158"/>
+        <source>%0% (%1/%2)</source>
+        <translation>%0% (%1/%2)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1248"/>
+        <source>No</source>
+        <translation>Нет</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1248"/>
+        <source>Yes</source>
+        <translation>Да</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1255"/>
+        <source>Bronze</source>
+        <comment>Trophy type</comment>
+        <translation>Бронза</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1256"/>
+        <source>Silver</source>
+        <comment>Trophy type</comment>
+        <translation>Серебро</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1257"/>
+        <source>Gold</source>
+        <comment>Trophy type</comment>
+        <translation>Золото</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_manager_dialog.cpp" line="1258"/>
+        <source>Platinum</source>
+        <comment>Trophy type</comment>
+        <translation>Платина</translation>
+    </message>
+</context>
+<context>
+    <name>trophy_notification_frame</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_notification_frame.cpp" line="44"/>
+        <source>You have earned the Bronze trophy.
+%1</source>
+        <translation>Вы получили бронзовый трофей.
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_notification_frame.cpp" line="45"/>
+        <source>You have earned the Silver trophy.
+%1</source>
+        <translation>Вы получили серебряный трофей.
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_notification_frame.cpp" line="46"/>
+        <source>You have earned the Gold trophy.
+%1</source>
+        <translation>Вы получили золотой трофей.
+%1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/trophy_notification_frame.cpp" line="47"/>
+        <source>You have earned the Platinum trophy.
+%1</source>
+        <translation>Вы получили платиновый трофей.
+%1</translation>
+    </message>
+</context>
+<context>
+    <name>update_manager</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="86"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="101"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="204"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="416"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="424"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="436"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="765"/>
+        <source>Auto-updater</source>
+        <translation>Автообновление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="86"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="101"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="424"/>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="436"/>
+        <source>An error occurred during the auto-updating process.
+Check the log for more information.</source>
+        <translation>В процессе автоматического обновления произошла ошибка.
+Дополнительную информацию смотрите в журнале.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="113"/>
+        <source>Checking For Updates</source>
+        <translation>Проверка обновлений</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="204"/>
+        <source>Your version is already up to date!</source>
+        <translation>Ваша версия уже актуальна!</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="328"/>
+        <source>&lt;br&gt;You can empower our project at &lt;a href=&quot;https://rpcs3.net/patreon&quot;&gt;RPCS3 Patreon&lt;/a&gt;.&lt;br&gt;</source>
+        <translation>&lt;br&gt;Вы можете поддержать наш проект на &lt;a href=&quot;https://rpcs3.net/patreon&quot;&gt;RPCS3 Patreon&lt;/a&gt;.&lt;br&gt;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="336"/>
+        <source>A better version of RPCS3 is available!&lt;br&gt;&lt;br&gt;Current version: %0 (%1)&lt;br&gt;Better version: %2 (%3)&lt;br&gt;%4&lt;br&gt;Do you want to update?</source>
+        <translation>Доступна лучшая версия RPCS3!&lt;br&gt;&lt;br&gt;Текущая версия: %0 (%1)&lt;br&gt;Лучшая версия: %2 (%3)&lt;br&gt;%4&lt;br&gt;Хотите обновиться?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="345"/>
+        <source>A new version of RPCS3 is available!&lt;br&gt;&lt;br&gt;Current version: %0 (%1)&lt;br&gt;Latest version: %2 (%3)&lt;br&gt;Your version is %4 behind.&lt;br&gt;%5&lt;br&gt;Do you want to update?</source>
+        <translation>Доступна новая версия RPCS3!&lt;br&gt;&lt;br&gt;Текущая версия: %0 (%1)&lt;br&gt;Последняя версия: %2 (%3)&lt;br&gt;Ваша версия отстаёт на %4.&lt;br&gt;%5&lt;br&gt;Хотите обновиться?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="356"/>
+        <source>You&apos;re currently using a custom or PR build.&lt;br&gt;&lt;br&gt;Latest version: %0 (%1)&lt;br&gt;The latest version is %2 old.&lt;br&gt;%3&lt;br&gt;Do you want to update to the latest official RPCS3 version?</source>
+        <translation>Вы используете пользовательскую или PR-сборку.&lt;br&gt;&lt;br&gt;Последняя версия: %0 (%1)&lt;br&gt;Последняя версия вышла %2 назад.&lt;br&gt;%3&lt;br&gt;Хотите обновиться до последней официальной версии RPCS3?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="369"/>
+        <source>• %0: %1</source>
+        <translation>• %0: %1</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="369"/>
+        <source>N/A</source>
+        <translation>Н/Д</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="372"/>
+        <source>Update Available</source>
+        <translation>Доступно обновление</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="374"/>
+        <source>Don&apos;t show again for this version</source>
+        <translation>Не показывать снова для этой версии</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="378"/>
+        <source>To see the changelog, please click &quot;Show Details&quot;.</source>
+        <translation>Чтобы просмотреть список изменений, нажмите &quot;Показать детали&quot;.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="379"/>
+        <source>Changelog:
+
+%0</source>
+        <translation>Список изменений:
+
+%0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="416"/>
+        <source>Please stop the emulation before trying to update.</source>
+        <translation>Пожалуйста, остановите эмуляцию перед обновлением.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="443"/>
+        <source>Downloading Update</source>
+        <translation>Загрузка обновления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="450"/>
+        <source>Updating RPCS3</source>
+        <translation>Обновление RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/update_manager.cpp" line="765"/>
+        <source>Update successful!&lt;br&gt;RPCS3 will now restart.&lt;br&gt;</source>
+        <translation>Обновление успешно!&lt;br&gt;RPCS3 будет перезапущен.&lt;br&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>user_manager_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="35"/>
+        <source>User Manager</source>
+        <translation>Менеджер пользователей</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="53"/>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="406"/>
+        <source>User ID</source>
+        <translation>ID пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="53"/>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="407"/>
+        <source>User Name</source>
+        <translation>Имя пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="59"/>
+        <source>&amp;Delete User</source>
+        <translation>&amp;Удалить пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="62"/>
+        <source>&amp;Create User</source>
+        <translation>&amp;Создать пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="65"/>
+        <source>&amp;Log In User</source>
+        <translation>&amp;Войти под пользователем</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="68"/>
+        <source>&amp;Rename User</source>
+        <translation>&amp;Переименовать пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="71"/>
+        <source>&amp;Close</source>
+        <translation>&amp;Закрыть</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="223"/>
+        <source>Delete Confirmation</source>
+        <translation>Подтверждение удаления</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="223"/>
+        <source>Are you sure you want to delete the following user?
+
+User ID: %0
+Username: %1
+
+This will remove all files in:
+%2</source>
+        <translation>Вы уверены, что хотите удалить следующего пользователя?
+
+ID пользователя: %0
+Имя пользователя: %1
+
+Это удалит все файлы в:
+%2</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="271"/>
+        <source>Rename User</source>
+        <translation>Переименовать пользователя</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="272"/>
+        <source>User Id: %0
+Old Username: %1
+
+New Username: </source>
+        <translation>ID пользователя: %0
+Старое имя: %1
+
+Новое имя: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="283"/>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="321"/>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="340"/>
+        <source>Error</source>
+        <translation>Ошибка</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="283"/>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="340"/>
+        <source>Name must be between 3 and 16 characters and only consist of letters, numbers, underscores, and hyphens.</source>
+        <translation>Имя должно содержать от 3 до 16 символов и состоять только из букв, цифр, символов подчёркивания и дефисов.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="321"/>
+        <source>Cannot add more users.</source>
+        <translation>Нельзя добавить больше пользователей.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="329"/>
+        <source>New User</source>
+        <translation>Новый пользователь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="330"/>
+        <source>New User ID: %0
+
+New Username: </source>
+        <translation>Новый ID пользователя: %0
+
+Новое имя пользователя: </translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="354"/>
+        <source>Stop emulator?</source>
+        <translation>Остановить эмулятор?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="355"/>
+        <source>In order to change the user you have to stop the emulator first.
+
+Stop the emulator now?</source>
+        <translation>Для смены пользователя необходимо сначала остановить эмулятор.
+
+Остановить эмулятор сейчас?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="405"/>
+        <source>&amp;Sort By</source>
+        <translation>&amp;Сортировать по</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="409"/>
+        <source>&amp;Remove</source>
+        <translation>&amp;Удалить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="410"/>
+        <source>&amp;Rename</source>
+        <translation>&amp;Переименовать</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="411"/>
+        <source>&amp;Login</source>
+        <translation>&amp;Войти</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/user_manager_dialog.cpp" line="412"/>
+        <source>&amp;Open User Directory</source>
+        <translation>&amp;Открыть папку пользователя</translation>
+    </message>
+</context>
+<context>
+    <name>vfs_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog.cpp" line="19"/>
+        <source>Virtual File System</source>
+        <translation>Виртуальная файловая система</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog.cpp" line="50"/>
+        <source>Reset Directories</source>
+        <translation>Сбросить директории</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog.cpp" line="57"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog.cpp" line="57"/>
+        <source>Reset all file system directories?</source>
+        <translation>Сбросить все директории файловой системы?</translation>
+    </message>
+</context>
+<context>
+    <name>vfs_dialog_path_widget</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp" line="28"/>
+        <source>Add new directory</source>
+        <translation>Добавить директорию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp" line="33"/>
+        <source>Remove directory</source>
+        <translation>Удалить директорию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp" line="40"/>
+        <source>Used %0 directory:</source>
+        <translation>Используемая директория %0:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_path_widget.cpp" line="118"/>
+        <source>Choose a directory</source>
+        <translation>Выбрать директорию</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_path_widget.h" line="36"/>
+        <source>Empty Path</source>
+        <translation>Пустой путь</translation>
+    </message>
+</context>
+<context>
+    <name>vfs_dialog_usb_input</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="17"/>
+        <source>Edit %0</source>
+        <translation>Редактировать %0</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="28"/>
+        <source>Reset All</source>
+        <translation>Сбросить всё</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="46"/>
+        <source>Confirm Reset</source>
+        <translation>Подтверждение сброса</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="46"/>
+        <source>Reset all entries and file system directories?</source>
+        <translation>Сбросить все записи и директории файловой системы?</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="75"/>
+        <source>Vendor ID:</source>
+        <translation>Vendor ID:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="76"/>
+        <source>Product ID:</source>
+        <translation>Product ID:</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_input.cpp" line="77"/>
+        <source>Serial:</source>
+        <translation>Серийный номер:</translation>
+    </message>
+</context>
+<context>
+    <name>vfs_dialog_usb_tab</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_dialog_usb_tab.cpp" line="151"/>
+        <source>&amp;Edit</source>
+        <translation>&amp;Редактировать</translation>
+    </message>
+</context>
+<context>
+    <name>vfs_tool_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_tool_dialog.ui" line="14"/>
+        <source>VFS Tool</source>
+        <translation>Инструмент VFS</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_tool_dialog.ui" line="20"/>
+        <source>Path</source>
+        <translation>Путь</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/vfs_tool_dialog.ui" line="36"/>
+        <source>Result</source>
+        <translation>Результат</translation>
+    </message>
+</context>
+<context>
+    <name>welcome_dialog</name>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="20"/>
+        <source>Welcome to RPCS3</source>
+        <translation>Добро пожаловать в RPCS3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="98"/>
+        <source>RPCS3 PlayStation 3 Emulator</source>
+        <translation>RPCS3 — эмулятор PlayStation 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="180"/>
+        <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;RPCS3 does not condone piracy. You must dump your own games.&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;span style=&quot; font-weight:600; color:#ff0000;&quot;&gt;RPCS3 не поощряет пиратство. Вы должны снимать образы собственных игр.&lt;/span&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="190"/>
+        <source>Create desktop shortcut</source>
+        <translation>Создать ярлык на рабочем столе</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="197"/>
+        <source>Create Start Menu shortcut</source>
+        <translation>Создать ярлык в меню «Пуск»</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="204"/>
+        <source>Use Dark Theme (can be configured later)</source>
+        <translation>Использовать тёмную тему (можно изменить позже)</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="238"/>
+        <source>Continue</source>
+        <translation>Продолжить</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="248"/>
+        <source>Exit</source>
+        <translation>Выход</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="271"/>
+        <source>I have read the Quickstart guide</source>
+        <translation>Я прочитал руководство по быстрому старту</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.ui" line="291"/>
+        <source>Show at startup</source>
+        <translation>Показывать при запуске</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="27"/>
+        <source>RPCS3 is an open-source Sony PlayStation 3 emulator and debugger.
+It is written in C++ for Windows, Linux, FreeBSD and MacOS funded with %0.
+Our developers and contributors are always working hard to ensure this project is the best that it can be.
+There are still plenty of implementations to make and optimizations to do.</source>
+        <translation>RPCS3 — это эмулятор и отладчик Sony PlayStation 3 с открытым исходным кодом.
+Написан на C++ для Windows, Linux, FreeBSD и MacOS и финансируется через %0.
+Наши разработчики и участники постоянно работают над тем, чтобы сделать этот проект максимально качественным.
+Ещё предстоит немало реализовать и оптимизировать.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="32"/>
+        <source>Patreon</source>
+        <translation>Patreon</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="34"/>
+        <source>To get started, you must first install the %0.
+Please refer to the %1 guide found on the official website for further information.
+If you have any further questions, please refer to the %2.
+Otherwise, further discussion and support can be found on the %3 or on our %4 server.</source>
+        <translation>Для начала работы необходимо установить %0.
+Подробную информацию смотрите в руководстве %1 на официальном сайте.
+Если у вас есть вопросы, обратитесь к разделу %2.
+Для дополнительного обсуждения и поддержки посетите %3 или наш сервер %4.</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="39"/>
+        <source>PlayStation 3 firmware</source>
+        <translation>прошивку PlayStation 3</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="40"/>
+        <source>Quickstart</source>
+        <translation>Quickstart</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="41"/>
+        <source>FAQ</source>
+        <translation>FAQ</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="42"/>
+        <source>Forums</source>
+        <translation>Форумы</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="43"/>
+        <source>Discord</source>
+        <translation>Discord</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="46"/>
+        <source>&amp;Create Launchpad shortcut</source>
+        <translation>&amp;Создать ярлык в Launchpad</translation>
+    </message>
+    <message>
+        <location filename="rpcs3/rpcs3qt/welcome_dialog.cpp" line="51"/>
+        <source>&amp;Create Application Menu shortcut</source>
+        <translation>&amp;Создать ярлык в меню приложений</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
## Summary

This PR adds the first complete Russian translation of RPCS3.

- **Language**: Russian (ru_RU)
- **Strings**: 3237 / 3237 (100% complete)
- All accelerator keys (`&`) preserved for keyboard navigation
- Plural forms implemented (3 forms as required by Russian grammar rules)
- Technical terms kept untranslated: PPU, SPU, RSX, XInput, evdev, DS3, DS4, DualSense, etc.

## Notes

Translated manually for quality. Ready for inclusion in official builds.